### PR TITLE
Allow user specific CXXFLAGS.

### DIFF
--- a/configure
+++ b/configure
@@ -126,8 +126,8 @@ fi
 if [ x"$CXXFLAGS" ]
 then
   case x"$CXX" in
-    xg++*|xclang++*) CXXFLAGS="-Wall";;
-    *) CXXFLAGS="-W";;
+    xg++*|xclang++*) CXXFLAGS="$CXXFLAGS -Wall";;
+    *) CXXFLAGS="$CXXFLAGS -W";;
   esac
   if [ $debug = yes ]
   then


### PR DESCRIPTION
Only append to CXXFLAGS in configure script in order to allow user specific CXXFLAGS,
e.g., CXXFLAGS="-fPIC" ./configure