### PR TITLE
Fix LRAT error handling in Solver::set().

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -456,7 +456,7 @@ bool Solver::set (const char *arg, int val) {
         "can only set option 'set (\"%s\", %d)' right after initialization",
         arg, val);
   }
-  if (strcmp (arg, "lrat")) {
+  if (!strcmp (arg, "lrat")) {
     REQUIRE (!internal->external_prop,
              "lrat is currently not compatible with external propagation");
   }


### PR DESCRIPTION
This fixes incorrect error handling to guard not using lrat with
external propagators, which caused the guard to fire every time
Solver::set() was called.