### PR TITLE
WIP: C interface for IPASIR-UP

### DIFF
--- a/src/ccadical.cpp
+++ b/src/ccadical.cpp
@@ -61,6 +61,84 @@ struct Wrapper : Learner, Terminator {
   }
 };
 
+struct PropagatorWrapper : ExternalPropagator {
+  void *state;
+
+  void (*notify_assignment_fn) (void *state, int lit, bool is_fixed);
+  void (*notify_new_decision_level_fn) (void *state);
+  void (*notify_backtrack_fn) (void *state, size_t new_level);
+
+  bool (*check_model_fn) (void *state, size_t size, const int *model);
+  int (*decide_fn) (void *state);
+  int (*propagate_fn) (void *state);
+  int (*add_reason_clause_lit_fn) (void *state, int propagated_lit);
+  bool (*has_external_clause_fn) (void *state);
+  int (*add_external_clause_lit_fn) (void *state);
+
+  PropagatorWrapper (void *state)
+      : state (state), notify_assignment_fn (nullptr),
+        notify_new_decision_level_fn (nullptr),
+        notify_backtrack_fn (nullptr), check_model_fn (nullptr),
+        propagate_fn (nullptr), add_reason_clause_lit_fn (nullptr),
+        has_external_clause_fn (nullptr),
+        add_external_clause_lit_fn (nullptr) {}
+
+  virtual void notify_assignment (int lit, bool is_fixed) {
+    if (notify_assignment_fn != nullptr) {
+      notify_assignment_fn (state, lit, is_fixed);
+    }
+  };
+  virtual void notify_new_decision_level () {
+    if (notify_new_decision_level_fn != nullptr) {
+      notify_new_decision_level_fn (state);
+    }
+  };
+  virtual void notify_backtrack (size_t new_level) {
+    if (notify_backtrack_fn != nullptr) {
+      notify_backtrack_fn (state, new_level);
+    }
+  };
+
+  virtual bool cb_check_found_model (const std::vector<int> &model) {
+    if (check_model_fn != nullptr) {
+      return check_model_fn (state, model.size (), model.data ());
+    }
+    return true;
+  };
+  virtual int cb_decide () {
+    if (decide_fn != nullptr) {
+      return decide_fn (state);
+    }
+    return 0;
+  };
+  virtual int cb_propagate () {
+    if (propagate_fn != nullptr) {
+      return propagate_fn (state);
+    }
+    return 0;
+  };
+
+  virtual int cb_add_reason_clause_lit (int propagated_lit) {
+    if (add_reason_clause_lit_fn != nullptr) {
+      return add_reason_clause_lit_fn (state, propagated_lit);
+    }
+    return 0;
+  };
+
+  virtual bool cb_has_external_clause () {
+    if (has_external_clause_fn != nullptr) {
+      return has_external_clause_fn (state);
+    }
+    return false;
+  };
+  virtual int cb_add_external_clause_lit () {
+    if (add_external_clause_lit_fn != nullptr) {
+      return add_external_clause_lit_fn (state);
+    }
+    return 0;
+  };
+};
+
 } // namespace CaDiCaL
 
 using namespace CaDiCaL;
@@ -172,5 +250,95 @@ void ccadical_melt (CCaDiCaL *ptr, int lit) {
 
 int ccadical_frozen (CCaDiCaL *ptr, int lit) {
   return ((Wrapper *) ptr)->solver->frozen (lit);
+}
+
+void ccadical_connect_external_propagator (CCaDiCaL *slv,
+                                           CCaDiCaLPropagator *prop) {
+  ((Wrapper *) slv)
+      ->solver->connect_external_propagator (((PropagatorWrapper *) prop));
+}
+void ccadical_disconnect_external_propagator (CCaDiCaL *slv) {
+  ((Wrapper *) slv)->solver->disconnect_external_propagator ();
+}
+
+void ccadical_add_observed_var (CCaDiCaL *slv, int var) {
+  ((Wrapper *) slv)->solver->add_observed_var (var);
+}
+void ccadical_remove_observed_var (CCaDiCaL *slv, int var) {
+  ((Wrapper *) slv)->solver->remove_observed_var (var);
+}
+void ccadical_reset_observed_vars (CCaDiCaL *slv) {
+  ((Wrapper *) slv)->solver->reset_observed_vars ();
+}
+bool ccadical_is_decision (CCaDiCaL *slv, int lit) {
+  return ((Wrapper *) slv)->solver->is_decision (lit);
+}
+
+void ccadical_phase (CCaDiCaL *slv, int lit) {
+  ((Wrapper *) slv)->solver->phase (lit);
+}
+void ccadical_unphase (CCaDiCaL *slv, int lit) {
+  ((Wrapper *) slv)->solver->unphase (lit);
+}
+
+CCaDiCaLPropagator *ccadical_prop_init (void *state) {
+  return (CCaDiCaLPropagator *) new PropagatorWrapper (state);
+}
+void ccadical_prop_release (CCaDiCaLPropagator *prop) {
+  delete (PropagatorWrapper *) prop;
+}
+void ccadical_prop_lazy (CCaDiCaLPropagator *prop, bool is_lazy) {
+  ((PropagatorWrapper *) prop)->is_lazy = is_lazy;
+}
+
+void ccadical_prop_set_notify_assignment (
+    CCaDiCaLPropagator *prop,
+    void (*notify_assignment) (void *state, int lit, bool is_fixed)) {
+  ((PropagatorWrapper *) prop)->notify_assignment_fn = notify_assignment;
+}
+void ccadical_prop_set_notify_new_decision_level (
+    CCaDiCaLPropagator *prop,
+    void (*notify_new_decision_level) (void *state)) {
+  ((PropagatorWrapper *) prop)->notify_new_decision_level_fn =
+      notify_new_decision_level;
+}
+void ccadical_prop_set_notify_backtrack (
+    CCaDiCaLPropagator *prop,
+    void (*notify_backtrack) (void *state, size_t new_level)) {
+  ((PropagatorWrapper *) prop)->notify_backtrack_fn = notify_backtrack;
+}
+
+void ccadical_prop_set_check_model (
+    CCaDiCaLPropagator *prop,
+    bool (*check_model) (void *state, size_t size, const int *model)) {
+  ((PropagatorWrapper *) prop)->check_model_fn = check_model;
+}
+
+void ccadical_prop_set_decide (CCaDiCaLPropagator *prop,
+                               int (*decide) (void *state)) {
+  ((PropagatorWrapper *) prop)->decide_fn = decide;
+}
+void ccadical_prop_set_propagate (CCaDiCaLPropagator *prop,
+                                  int (*propagate) (void *state)) {
+  ((PropagatorWrapper *) prop)->propagate_fn = propagate;
+}
+
+void ccadical_prop_set_add_reason_clause_lit (
+    CCaDiCaLPropagator *prop,
+    int (*add_reason_clause_lit) (void *state, int propagated_lit)) {
+  ((PropagatorWrapper *) prop)->add_reason_clause_lit_fn =
+      add_reason_clause_lit;
+}
+
+void ccadical_prop_set_has_external_clause (
+    CCaDiCaLPropagator *prop, bool (*has_external_clause) (void *state)) {
+  ((PropagatorWrapper *) prop)->has_external_clause_fn =
+      has_external_clause;
+}
+void ccadical_prop_set_add_external_clause_lit (
+    CCaDiCaLPropagator *prop,
+    int (*add_external_clause_lit) (void *state)) {
+  ((PropagatorWrapper *) prop)->add_external_clause_lit_fn =
+      add_external_clause_lit;
 }
 }

--- a/src/ccadical.h
+++ b/src/ccadical.h
@@ -7,6 +7,7 @@ extern "C" {
 #endif
 /*------------------------------------------------------------------------*/
 
+#include <stddef.h>
 #include <stdint.h>
 
 // C wrapper for CaDiCaL's C++ API following IPASIR.
@@ -28,6 +29,55 @@ void ccadical_set_terminate (CCaDiCaL *, void *state,
 
 void ccadical_set_learn (CCaDiCaL *, void *state, int max_length,
                          void (*learn) (void *state, int *clause));
+
+/*------------------------------------------------------------------------*/
+
+// C wrapper for CaDiCaL's C++ API following IPASIR-UP.
+
+typedef struct CCaDiCaLPropagator CCaDiCaLPropagator;
+
+void ccadical_connect_external_propagator (CCaDiCaL *,
+                                           CCaDiCaLPropagator *);
+void ccadical_disconnect_external_propagator (CCaDiCaL *);
+
+void ccadical_add_observed_var (CCaDiCaL *, int var);
+void ccadical_remove_observed_var (CCaDiCaL *, int var);
+void ccadical_reset_observed_vars (CCaDiCaL *);
+bool ccadical_is_decision (CCaDiCaL *, int lit);
+
+void ccadical_phase (CCaDiCaL *, int lit);
+void ccadical_unphase (CCaDiCaL *, int lit);
+
+CCaDiCaLPropagator *ccadical_prop_init (void *state);
+void ccadical_prop_release (CCaDiCaLPropagator *);
+void ccadical_prop_lazy (CCaDiCaLPropagator *, bool is_lazy);
+
+void ccadical_prop_set_notify_assignment (
+    CCaDiCaLPropagator *,
+    void (*notify_assignment) (void *state, int lit, bool is_fixed));
+void ccadical_prop_set_notify_new_decision_level (
+    CCaDiCaLPropagator *, void (*notify_new_decision_level) (void *state));
+void ccadical_prop_set_notify_backtrack (
+    CCaDiCaLPropagator *,
+    void (*notify_backtrack) (void *state, size_t new_level));
+
+void ccadical_prop_set_check_model (CCaDiCaLPropagator *,
+                                    bool (*check_model) (void *state,
+                                                         size_t size,
+                                                         const int *model));
+void ccadical_prop_set_decide (CCaDiCaLPropagator *,
+                               int (*decide) (void *state));
+void ccadical_prop_set_propagate (CCaDiCaLPropagator *,
+                                  int (*propagate) (void *state));
+
+void ccadical_prop_set_add_reason_clause_lit (
+    CCaDiCaLPropagator *,
+    int (*add_reason_clause_lit) (void *state, int propagated_lit));
+
+void ccadical_prop_set_has_external_clause (
+    CCaDiCaLPropagator *, bool (*has_external_clause) (void *state));
+void ccadical_prop_set_add_external_clause_lit (
+    CCaDiCaLPropagator *, int (*add_external_clause_lit) (void *state));
 
 /*------------------------------------------------------------------------*/
 

--- a/src/ipasir.cpp
+++ b/src/ipasir.cpp
@@ -1,5 +1,6 @@
 #include "ipasir.h"
 #include "ccadical.h"
+#include "ipasir_up.h"
 
 extern "C" {
 
@@ -39,5 +40,91 @@ void ipasir_set_terminate (void *solver, void *state,
 void ipasir_set_learn (void *solver, void *state, int max_length,
                        void (*learn) (void *state, int *clause)) {
   ccadical_set_learn ((CCaDiCaL *) solver, state, max_length, learn);
+}
+
+void ipasir_connect_external_propagator (void *solver, void *propagator) {
+  ccadical_connect_external_propagator ((CCaDiCaL *) solver,
+                                        (CCaDiCaLPropagator *) propagator);
+}
+void ipasir_disconnect_external_propagator (void *solver) {
+  ccadical_disconnect_external_propagator ((CCaDiCaL *) solver);
+}
+
+void ipasir_add_observed_var (void *solver, int32_t var) {
+  ccadical_add_observed_var ((CCaDiCaL *) solver, var);
+}
+void ipasir_remove_observed_var (void *solver, int32_t var) {
+  ccadical_remove_observed_var ((CCaDiCaL *) solver, var);
+}
+void ipasir_reset_observed_vars (void *solver) {
+  ccadical_reset_observed_vars ((CCaDiCaL *) solver);
+}
+
+bool ipasir_is_decision (void *solver, int32_t lit) {
+  return ccadical_is_decision ((CCaDiCaL *) solver, lit);
+}
+
+void ipasir_phase (void *solver, int32_t lit) {
+  ccadical_phase ((CCaDiCaL *) solver, lit);
+}
+void ipasir_unphase (void *solver, int32_t lit) {
+  ccadical_unphase ((CCaDiCaL *) solver, lit);
+}
+
+void *ipasir_prop_init (void *state) { return ccadical_prop_init (state); }
+void ipasir_prop_release (void *prop) {
+  return ccadical_prop_release ((CCaDiCaLPropagator *) prop);
+}
+
+void ipasir_prop_lazy (void *prop, bool is_lazy) {
+  ccadical_prop_lazy ((CCaDiCaLPropagator *) prop, is_lazy);
+}
+
+void ipasir_prop_set_notify_assignment (
+    void *prop,
+    void (*notify_assignment) (void *state, int32_t lit, bool is_fixed)) {
+  ccadical_prop_set_notify_assignment ((CCaDiCaLPropagator *) prop,
+                                       notify_assignment);
+}
+void ipasir_prop_set_notify_new_decision_level (
+    void *prop, void (*notify_new_decision_level) (void *state)) {
+  ccadical_prop_set_notify_new_decision_level ((CCaDiCaLPropagator *) prop,
+                                               notify_new_decision_level);
+}
+void ipasir_prop_set_notify_backtrack (
+    void *prop, void (*notify_backtrack) (void *state, size_t new_level)) {
+  ccadical_prop_set_notify_backtrack ((CCaDiCaLPropagator *) prop,
+                                      notify_backtrack);
+}
+
+void ipasir_prop_set_check_model (
+    void *prop,
+    bool (*check_model) (void *state, size_t size, const int32_t *model)) {
+  ccadical_prop_set_check_model ((CCaDiCaLPropagator *) prop, check_model);
+}
+void ipasir_prop_set_decide (void *prop, int32_t (*decide) (void *state)) {
+  ccadical_prop_set_decide ((CCaDiCaLPropagator *) prop, decide);
+}
+void ipasir_prop_set_propagate (void *prop,
+                                int32_t (*propagate) (void *state)) {
+  ccadical_prop_set_propagate ((CCaDiCaLPropagator *) prop, propagate);
+}
+
+void ipasir_prop_set_add_reason_clause_lit (
+    void *prop,
+    int32_t (*add_reason_clause_lit) (void *state, int propagated_lit)) {
+  ccadical_prop_set_add_reason_clause_lit ((CCaDiCaLPropagator *) prop,
+                                           add_reason_clause_lit);
+}
+
+void ipasir_prop_set_has_external_clause (
+    void *prop, bool (*has_external_clause) (void *state)) {
+  ccadical_prop_set_has_external_clause ((CCaDiCaLPropagator *) prop,
+                                         has_external_clause);
+}
+void ipasir_prop_set_add_external_clause_lit (
+    void *prop, int32_t (*add_external_clause_lit) (void *state)) {
+  ccadical_prop_set_add_external_clause_lit ((CCaDiCaLPropagator *) prop,
+                                             add_external_clause_lit);
 }
 }

--- a/src/ipasir_up.h
+++ b/src/ipasir_up.h
@@ -1,0 +1,145 @@
+#ifndef _ipasir_up_h_INCLUDED
+#define _ipasir_up_h_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*------------------------------------------------------------------------*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*------------------------------------------------------------------------*/
+
+// Add call-back which allows to learn, propagate and backtrack based on
+// external constraints. Only one external propagator can be connected
+// and after connection every related variables must be 'observed' (use
+// 'add_observed_var' function).
+// Disconnection of the external propagator resets all the observed
+// variables.
+//
+//   require (VALID)
+//   ensure (VALID)
+//
+void ipasir_connect_external_propagator (void *solver, void *propagator);
+void ipasir_disconnect_external_propagator (void *solver);
+
+// Mark as 'observed' those variables that are relevant to the external
+// propagator. External propagation, clause addition during search and
+// notifications are all over these observed variabes.
+// A variable can not be observed witouth having an external propagator
+// connected. Observed variables are "frozen" internally, and so
+// inprocessing will not consider them as candidates for elimination.
+// An observed variable is allowed to be a fresh variable and it can be
+// added also during solving.
+//
+//   require (VALID_OR_SOLVING)
+//   ensure (VALID_OR_SOLVING)
+//
+void ipasir_add_observed_var (void *solver, int32_t var);
+
+// Removes the 'observed' flag from the given variable. A variable can be
+// set unobserved only between solve calls, not during it (to guarantee
+// that no yet unexplained external propagation involves it).
+//
+//   require (VALID)
+//   ensure (VALID)
+//
+void ipasir_remove_observed_var (void *solver, int32_t var);
+
+// Removes all the 'observed' flags from the variables. Disconnecting the
+// propagator invokes this step as well.
+//
+//   require (VALID)
+//   ensure (VALID)
+//
+void ipasir_reset_observed_vars (void *solver);
+
+// Get reason of valid observed literal (true = it is an observed variable
+// and it got assigned by a decision during the CDCL loop. Otherwise:
+// false.
+//
+//   require (VALID_OR_SOLVING)
+//   ensure (VALID_OR_SOLVING)
+//
+bool ipasir_is_decision (void *solver, int32_t lit);
+
+void ipasir_phase (void *solver, int32_t lit);
+void ipasir_unphase (void *solver, int32_t lit);
+
+void *ipasir_prop_init (void *state);
+void ipasir_prop_release (void *prop);
+
+// This flag is currently checked only when the propagator is connected.
+// lazy propagator only checks complete assignments
+void ipasir_prop_lazy (void *prop, bool is_lazy);
+
+// Notify the propagator about assignments to observed variables.
+// The notification is not necessarily eager. It usually happens before
+// the call of propagator callbacks and when a driving clause is leading
+// to an assignment.
+void ipasir_prop_set_notify_assignment (
+    void *prop,
+    void (*notify_assignment) (void *state, int32_t lit, bool is_fixed));
+void ipasir_prop_set_notify_new_decision_level (
+    void *prop, void (*notify_new_decision_level) (void *state));
+void ipasir_prop_set_notify_backtrack (
+    void *prop, void (*notify_backtrack) (void *state, size_t new_level));
+
+// Check by the external propagator the found complete solution (after
+// solution reconstruction). If it returns false, the propagator must
+// provide an external clause during the next callback.
+void ipasir_prop_set_check_model (
+    void *prop,
+    bool (*check_model) (void *state, size_t size, const int32_t *model));
+
+// Ask the external propagator for the next decision literal. If it
+// returns 0, the solver makes its own choice.
+void ipasir_prop_set_decide (void *prop, int32_t (*decide) (void *state));
+
+// Ask the external propagator if there is an external propagation to make
+// under the current assignment. It returns either a literal to be
+// propagated or 0, indicating that there is no external propagation under
+// the current assignment.
+void ipasir_prop_set_propagate (void *prop,
+                                int32_t (*propagate) (void *state));
+
+// Ask the external propagator for the reason clause of a previous
+// external propagation step (done by cb_propagate). The clause must be
+// added literal-by-literal closed with a 0. Further, the clause must
+// contain the propagated literal.
+void ipasir_prop_set_add_reason_clause_lit (
+    void *prop,
+    int32_t (*add_reason_clause_lit) (void *state, int propagated_lit));
+
+// The following two functions are used to add external clauses to the
+// solver during the CDCL loop. The external clause is added
+// literal-by-literal and learned by the solver as an irredundant
+// (original) input clause. The clause can be arbitrary, but if it is
+// root-satisfied or tautology, the solver will ignore it without learning
+// it. Root-falsified literals are eagerly removed from the clause.
+// Falsified clauses trigger conflict analysis, propagating clauses
+// trigger propagation. In case chrono is 0, the solver backtracks to
+// propagate the new literal on the right decision level, otherwise it
+// potentially will be an out-of-order assignment on the current level.
+// Unit clauses always (unless root-satisfied, see above) trigger
+// backtracking (independently from the value of the chrono option and
+// independently from being falsified or satisfied or unassigned) to level
+// 0. Empty clause (or root falsified clause, see above) makes the problem
+// unsat and stops the search immediately. A literal 0 must close the
+// clause.
+
+// The external propagator indicates that there is a clause to add.
+void ipasir_prop_set_has_external_clause (
+    void *prop, bool (*has_external_clause) (void *state));
+
+// The actual function called to add the external clause.
+void ipasir_prop_set_add_external_clause_lit (
+    void *prop, int32_t (*add_external_clause_lit) (void *state));
+
+/*------------------------------------------------------------------------*/
+#ifdef __cplusplus
+}
+#endif
+/*------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
This PR adds a C interface for the functionality added by the IPASIR-UP API. The `CCaDiCaLPropagator` has a single attached `state` that is given to all call back functions added to the external propagator.

I've tried to keep all code in IPASIR and CCaDiCaL as much in style as possible.

I've marked this PR as `WIP` because the comments added are currently only copied from the triggered code. I will adjust them to be specific to the interface, and add the missing documentation to the undocumented functions.

I would love to get any feedback on the interface design, code style, or any other details