### PR TITLE
Fixing Option Ordering

### DIFF
--- a/src/options.hpp
+++ b/src/options.hpp
@@ -98,6 +98,7 @@ OPTION( flushfactor,       3,  1,1e3,0,0,1, "interval increase") \
 OPTION( flushint,        1e5,  1,2e9,0,0,1, "initial limit") \
 OPTION( forcephase,        0,  0,  1,0,0,1, "always use initial phase") \
 OPTION( frat,              0,  0,  2,0,0,1, "1=frat(lrat), 2=frat(drat)") \
+OPTION( idrup,              0,  0,  1,0,0,1, "incremental proof format") \
 OPTION( ilb,               1,  0,  1,0,0,1, "ILB (incremental lazy backtrack)") \
 OPTION( ilbassumptions,    1,  0,  1,0,0,1, "trail reuse for assumptions (ILB-like)") \
 OPTION( inprocessing,      1,  0,  1,0,0,1, "enable inprocessing") \
@@ -105,7 +106,6 @@ OPTION( instantiate,       0,  0,  1,0,1,1, "variable instantiation") \
 OPTION( instantiateclslim, 3,  2,2e9,0,0,1, "minimum clause size") \
 OPTION( instantiateocclim, 1,  1,2e9,2,0,1, "maximum occurrence limit") \
 OPTION( instantiateonce,   1,  0,  1,0,0,1, "instantiate each clause once") \
-OPTION( idrup,              0,  0,  1,0,0,1, "incremental proof format") \
 LOGOPT( log,               0,  0,  1,0,0,0, "enable logging") \
 LOGOPT( logsort,           0,  0,  1,0,0,0, "sort logged clauses") \
 OPTION( lrat,              0,  0,  1,0,0,1, "use lrat proof format") \


### PR DESCRIPTION
Resolving the following error after compilation:
cadical: fatal error: 'instantiateonce' ordered before 'idrup' in 'options.hpp'