### PR TITLE
Fixed missing labels in CraigTracer test case

### DIFF
--- a/test/contrib/craigtracer_incremental.cpp
+++ b/test/contrib/craigtracer_incremental.cpp
@@ -47,6 +47,8 @@ int main () {
   assert (next_var == 2);
 
   // ------------------------------------------------
+  tracer->label_clause (3, CaDiCraig::CraigClauseType::A_CLAUSE);
+  tracer->label_constraint (CaDiCraig::CraigClauseType::B_CLAUSE);
   solver->add (-1); solver->add (3); solver->add (0);
   solver->constrain (-2); solver->constrain (-3); solver->constrain (0);
   assert (solver->solve () == CaDiCaL::Status::UNSATISFIABLE);


### PR DESCRIPTION
Test case is fixed now:

```bash
make -C .. contrib
make[1]: Entering directory '/home/fallert/Source/cadical/test'
---------------------------------------------------------
Contributions testing in '../build'
---------------------------------------------------------
make[2]: Entering directory '/home/fallert/Source/cadical/build'
/home/fallert/Source/cadical/scripts/make-build-header.sh > build.hpp
g++ -Wall -Wextra -g -I../build -I/home/fallert/Source/cadical/src -c /home/fallert/Source/cadical/src/version.cpp -o src/version.o
ar rc libcadical.a src/analyze.o src/arena.o src/assume.o src/averages.o src/backtrack.o src/backward.o src/bins.o src/block.o src/ccadical.o src/checker.o src/clause.o src/collect.o src/compact.o src/condition.o src/config.o src/constrain.o src/contract.o src/cover.o src/decide.o src/decompose.o src/deduplicate.o src/drattracer.o src/elim.o src/ema.o src/extend.o src/external.o src/external_propagate.o src/file.o src/flags.o src/flip.o src/format.o src/frattracer.o src/gates.o src/idruptracer.o src/instantiate.o src/internal.o src/ipasir.o src/lidruptracer.o src/limit.o src/logging.o src/lookahead.o src/lratbuilder.o src/lratchecker.o src/lrattracer.o src/lucky.o src/message.o src/minimize.o src/occs.o src/options.o src/parse.o src/phases.o src/probe.o src/profile.o src/proof.o src/propagate.o src/queue.o src/random.o src/reap.o src/reduce.o src/rephase.o src/report.o src/resources.o src/restart.o src/restore.o src/score.o src/shrink.o src/signal.o src/solution.o src/solver.o src/stats.o src/subsume.o src/terminal.o src/ternary.o src/transred.o src/util.o src/var.o src/veripbtracer.o src/version.o src/vivify.o src/walk.o src/watch.o contrib/craigtracer.o
g++ -Wall -Wextra -g -I../build -I/home/fallert/Source/cadical/src -o cadical src/cadical.o -L. -lcadical 
g++ -Wall -Wextra -g -I../build -I/home/fallert/Source/cadical/src -o mobical src/mobical.o -L. -lcadical
make[2]: Leaving directory '/home/fallert/Source/cadical/build'
test/contrib/run.sh: using CXX=g++
test/contrib/run.sh: using CXXFLAGS=-Wall -Wextra -g
test/contrib/run.sh: running contrib test 'craigtracer'
g++ -Wall -Wextra -g -I../src -I../contrib -o ../build/test-contrib-craigtracer.o -c ../test/contrib/craigtracer.cpp
g++ -Wall -Wextra -g -o ../build/test-contrib-craigtracer ../build/test-contrib-craigtracer.o -L../build -lcadical
../build/test-contrib-craigtracer
# 0 ... ok (zero exit code)
test/contrib/run.sh: running contrib test 'craigtracer_incremental'
g++ -Wall -Wextra -g -I../src -I../contrib -o ../build/test-contrib-craigtracer_incremental.o -c ../test/contrib/craigtracer_incremental.cpp
g++ -Wall -Wextra -g -o ../build/test-contrib-craigtracer_incremental ../build/test-contrib-craigtracer_incremental.o -L../build -lcadical
../build/test-contrib-craigtracer_incremental
# 0 ... ok (zero exit code)
test/contrib/run.sh: contrib testing results: 2 ok, 0 failed
make[1]: Leaving directory '/home/fallert/Source/cadical/test'
```