### PR TITLE
modify the `LC_TIME` from `en_US` to `C`

### DIFF
--- a/scripts/make-build-header.sh
+++ b/scripts/make-build-header.sh
@@ -81,7 +81,7 @@ fi
 #--------------------------------------------------------------------------#
 # Use time of executing this script at build time.
 #
-LC_TIME="en_US" # Avoid umlaut in 'DATE'.
+LC_TIME="C" # Avoid umlaut in 'DATE'.
 export LC_TIME
 # The time and date we compiled the CaDiCaL library.
 DATE="`date 2>/dev/null|sed -e 's,  *, ,g'`"


### PR DESCRIPTION
Modify the `LC_TIME` from `en_US` (which might not exists, since it is `en_US.UTF8` that exists.) to `C`.

According to [GNU's documents](https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable), `LC_TIME=C` should always work, which seems better than `en_US`.