### PR TITLE
Add missing import to radix.hpp

### DIFF
--- a/src/radix.hpp
+++ b/src/radix.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstring>
 #include <iterator>
+#include <vector>
 
 namespace CaDiCaL {
 


### PR DESCRIPTION
`std::vector` is used in this header, but `<vector>` is never imported.