### PR TITLE
Add missing #include <netinet/in.h>

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -86,6 +86,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 }
 
 #endif


### PR DESCRIPTION
This fixes this build failure:
```
src/random.cpp:112:48: error: invalid application of 'sizeof' to an incomplete type 'struct sockaddr_in'
  112 |         const int size = (family == AF_INET) ? sizeof (struct sockaddr_in)
      |                                                ^      ~~~~~~~~~~~~~~~~~~~~
```

FreeBSD 14.1
