### PR TITLE
Fix issues with memory safety when allocation fails

### DIFF
--- a/src/arena.hpp
+++ b/src/arena.hpp
@@ -76,7 +76,8 @@ public:
   //
   bool contains (void *p) const {
     char *c = (char *) p;
-    return from.start <= c && c < from.top;
+    return (from.start <= c && c < from.top)
+      || (to.start <= c && c < to.top);
   }
 
   // Allocate that amount of memory in 'to' space.  This assumes the 'to'

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -40,6 +40,7 @@ CheckerClause *Checker::new_clause () {
   assert (size > 1), assert (size <= UINT_MAX);
   const size_t bytes = sizeof (CheckerClause) + (size - 2) * sizeof (int);
   CheckerClause *res = (CheckerClause *) new char[bytes];
+  DeferDeleteArray<char> delete_res ((char *) res);
   res->next = 0;
   res->hash = last_hash;
   res->size = size;
@@ -67,6 +68,7 @@ CheckerClause *Checker::new_clause () {
   watcher (literals[0]).push_back (CheckerWatch (literals[1], res));
   watcher (literals[1]).push_back (CheckerWatch (literals[0], res));
 
+  delete_res.release ();
   return res;
 }
 

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -461,6 +461,11 @@ void Checker::add_clause (const char *type) {
   (void) type;
 #endif
 
+  // If there are enough garbage clauses collect them first.
+  if (num_garbage >
+      0.5 * max ((size_t) size_clauses, (size_t) size_vars))
+    collect_garbage_clauses ();
+
   int unit = 0;
   for (const auto &lit : simplified) {
     const signed char tmp = val (lit);
@@ -560,10 +565,6 @@ void Checker::delete_clause (uint64_t id, bool, const vector<int> &c) {
       d->next = garbage;
       garbage = d;
       d->size = 0;
-      // If there are enough garbage clauses collect them.
-      if (num_garbage >
-          0.5 * max ((size_t) size_clauses, (size_t) size_vars))
-        collect_garbage_clauses ();
     } else {
       fatal_message_start ();
       fputs ("deleted clause not in proof:\n", stderr);

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -551,6 +551,8 @@ void Checker::delete_clause (uint64_t id, bool, const vector<int> &c) {
   START (checking);
   LOG (c, "CHECKER checking deletion of clause");
   stats.deleted++;
+  simplified.clear();  // Can be non-empty if clause allocation fails.
+  unsimplified.clear();  // Can be non-empty if clause allocation fails.
   import_clause (c);
   last_id = id;
   if (!tautological ()) {

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -230,12 +230,12 @@ void Checker::enlarge_vars (int64_t idx) {
   vals -= size_vars;
   delete[] vals;
   vals = new_vals;
+  size_vars = new_size_vars;
 
   watchers.resize (2 * new_size_vars);
   marks.resize (2 * new_size_vars);
 
   assert (idx < new_size_vars);
-  size_vars = new_size_vars;
 }
 
 inline void Checker::import_literal (int lit) {

--- a/src/checker.hpp
+++ b/src/checker.hpp
@@ -147,7 +147,7 @@ class Checker : public StatTracer {
 
 public:
   Checker (Internal *);
-  ~Checker ();
+  virtual ~Checker ();
 
   void connect_internal (Internal *i) override;
 

--- a/src/clause.cpp
+++ b/src/clause.cpp
@@ -579,10 +579,10 @@ Clause *Internal::new_clause_as (const Clause *orig) {
 //
 Clause *Internal::new_resolved_irredundant_clause () {
   external->check_learned_clause ();
-  Clause *res = new_clause (false);
   if (proof) {
-    proof->add_derived_clause (res, lrat_chain);
+    proof->add_derived_clause (clause_id + 1, false, clause, lrat_chain);
   }
+  Clause *res = new_clause (false);
   assert (!watching ());
   return res;
 }

--- a/src/clause.cpp
+++ b/src/clause.cpp
@@ -94,6 +94,7 @@ Clause *Internal::new_clause (bool red, int glue) {
 
   size_t bytes = Clause::bytes (size);
   Clause *c = (Clause *) new char[bytes];
+  DeferDeleteArray<char> clause_delete ((char *) c);
 
   c->id = ++clause_id;
 
@@ -140,6 +141,7 @@ Clause *Internal::new_clause (bool red, int glue) {
   }
 
   clauses.push_back (c);
+  clause_delete.release ();
   LOG (c, "new pointer %p", (void *) c);
 
   if (likely_to_be_kept_clause (c))

--- a/src/compact.cpp
+++ b/src/compact.cpp
@@ -411,6 +411,7 @@ void Internal::compact () {
     vals -= vsize;
     delete[] vals;
     vals = new_vals;
+    vsize = mapper.new_vsize;
   }
 
   // 'constrain' uses 'val', so this code has to be after remapping that
@@ -516,7 +517,6 @@ void Internal::compact () {
   /*----------------------------------------------------------------------*/
 
   max_var = mapper.new_max_var;
-  vsize = mapper.new_vsize;
 
   stats.unused = 0;
   stats.inactive = stats.now.fixed = mapper.first_fixed ? 1 : 0;

--- a/src/decompose.cpp
+++ b/src/decompose.cpp
@@ -167,7 +167,9 @@ bool Internal::decompose_round () {
 
   const size_t size_dfs = 2 * (1 + (size_t) max_var);
   DFS *dfs = new DFS[size_dfs];
+  DeferDeleteArray<DFS> dfs_delete (dfs);
   int *reprs = new int[size_dfs];
+  DeferDeleteArray<int> reprs_delete (reprs);
   clear_n (reprs, size_dfs);
   vector<vector<Clause *>> dfs_chains;
   dfs_chains.resize (size_dfs);
@@ -725,8 +727,8 @@ bool Internal::decompose_round () {
       mark_substituted (idx);
   }
 
-  delete[] reprs;
-  delete[] dfs;
+  reprs_delete.free ();
+  dfs_delete.free ();
   erase_vector (dfs_chains);
 
   flush_all_occs_and_watches (); // particularly the 'blit's

--- a/src/external.cpp
+++ b/src/external.cpp
@@ -747,6 +747,7 @@ void External::check_constraint_satisfied () {
 
 void External::check_failing () {
   Solver *checker = new Solver ();
+  DeferDeletePtr<Solver> delete_checker (checker);
   checker->prefix ("checker ");
 #ifdef LOGGING
   if (internal->opts.log)
@@ -789,7 +790,7 @@ void External::check_failing () {
   int res = checker->solve ();
   if (res != 20)
     FATAL ("failed assumptions do not form a core");
-  delete checker;
+  delete_checker.free ();
   VERBOSE (1, "checked that %zd failing assumptions form a core",
            assumptions.size ());
 }

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -142,6 +142,7 @@ void Internal::enlarge (int new_max_var) {
   enlarge_init (ptab, 2 * new_vsize, -1);
   enlarge_only (ftab, new_vsize);
   enlarge_vals (new_vsize);
+  vsize = new_vsize;
   enlarge_zero (frozentab, new_vsize);
   enlarge_zero (relevanttab, new_vsize);
   const signed char val = opts.phase ? 1 : -1;
@@ -152,7 +153,6 @@ void Internal::enlarge (int new_max_var) {
   enlarge_zero (phases.prev, new_vsize);
   enlarge_zero (phases.min, new_vsize);
   enlarge_zero (marks, new_vsize);
-  vsize = new_vsize;
 }
 
 void Internal::init_vars (int new_max_var) {

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -48,6 +48,11 @@ Internal::Internal ()
 }
 
 Internal::~Internal () {
+  // If a memory exception ocurred a profile might still be active.
+#define PROFILE(NAME, LEVEL) \
+  if (PROFILE_ACTIVE(NAME)) STOP(NAME);
+  PROFILES
+#undef PROFILE
   delete[](char *) dummy_binary;
   for (const auto &c : clauses)
     delete_clause (c);

--- a/src/lratbuilder.cpp
+++ b/src/lratbuilder.cpp
@@ -270,6 +270,7 @@ void LratBuilder::enlarge_vars (int64_t idx) {
   vals -= size_vars;
   delete[] vals;
   vals = new_vals;
+  size_vars = new_size_vars;
 
   reasons.resize (new_size_vars);
   unit_reasons.resize (new_size_vars);
@@ -287,7 +288,6 @@ void LratBuilder::enlarge_vars (int64_t idx) {
   checked_lits.resize (2 * new_size_vars);
 
   assert (idx < new_size_vars);
-  size_vars = new_size_vars;
 }
 
 inline void LratBuilder::import_literal (int lit) {

--- a/src/lratbuilder.cpp
+++ b/src/lratbuilder.cpp
@@ -695,6 +695,10 @@ void LratBuilder::add_clause (const char *type) {
   (void) type;
 #endif
 
+  // If there are enough garbage clauses collect them.
+  if (num_garbage > 0.5 * max ((size_t) size_clauses, (size_t) size_vars))
+    collect_garbage_clauses ();
+
   LratBuilderClause *c = insert ();
   if (inconsistent) {
     LOG ("LRAT BUILDER state already inconsistent so nothing more to do");
@@ -900,10 +904,6 @@ void LratBuilder::delete_clause (uint64_t id, const vector<int> &c) {
              d->id);
       }
     }
-
-    // If there are enough garbage clauses collect them.
-    if (num_garbage > 0.5 * max ((size_t) size_clauses, (size_t) size_vars))
-      collect_garbage_clauses ();
   } else {
     fatal_message_start ();
     fputs ("deleted clause not in proof:\n", stderr);

--- a/src/lratbuilder.cpp
+++ b/src/lratbuilder.cpp
@@ -54,6 +54,7 @@ LratBuilderClause *LratBuilder::new_clause () {
   const size_t bytes =
       sizeof (LratBuilderClause) + (size - off) * sizeof (int);
   LratBuilderClause *res = (LratBuilderClause *) new char[bytes];
+  DeferDeleteArray<char> delete_res ((char *) res);
   res->garbage = false;
   res->next = 0;
   res->hash = last_hash;
@@ -65,10 +66,12 @@ LratBuilderClause *LratBuilder::new_clause () {
     *p++ = lit;
 
   if (size == 0) {
+    delete_res.release ();
     return res;
   }
   if (size == 1) {
     unit_clauses.push_back (res);
+    delete_res.release ();
     return res;
   }
 
@@ -96,6 +99,7 @@ LratBuilderClause *LratBuilder::new_clause () {
   } else {
     LOG ("LRAT BUILDER clause not added to watchers");
   }
+  delete_res.release ();
   return res;
 }
 

--- a/src/lratchecker.hpp
+++ b/src/lratchecker.hpp
@@ -117,7 +117,7 @@ class LratChecker : public StatTracer {
 
 public:
   LratChecker (Internal *);
-  ~LratChecker ();
+  virtual ~LratChecker ();
 
   void connect_internal (Internal *i) override;
   void begin_proof (uint64_t) override;

--- a/src/profile.hpp
+++ b/src/profile.hpp
@@ -133,6 +133,10 @@ struct Profiles {
                                       internal->time ());) \
   } while (0)
 
+#define PROFILE_ACTIVE(P) \
+  ((internal->profiles.P.level <= internal->opts.profile) \
+    && (internal->profiles.P.active))
+
 /*------------------------------------------------------------------------*/
 
 #define START_SIMPLIFIER(S, M) \

--- a/src/proof.cpp
+++ b/src/proof.cpp
@@ -155,17 +155,21 @@ void Internal::check () {
   new_proof_on_demand ();
   if (opts.checkproof > 1) {
     StatTracer *lratchecker = new LratChecker (this);
+    DeferDeletePtr<LratChecker> delete_lratchecker ((LratChecker *) lratchecker);
     LOG ("PROOF connecting LRAT proof checker");
     force_lrat ();
     frat = true;
     proof->connect (lratchecker);
     stat_tracers.push_back (lratchecker);
+    delete_lratchecker.release ();
   }
   if (opts.checkproof == 1 || opts.checkproof == 3) {
     StatTracer *checker = new Checker (this);
+    DeferDeletePtr<Checker> delete_checker ((Checker *) checker);
     LOG ("PROOF connecting proof checker");
     proof->connect (checker);
     stat_tracers.push_back (checker);
+    delete_checker.release ();
   }
 }
 

--- a/src/proof.cpp
+++ b/src/proof.cpp
@@ -338,7 +338,7 @@ void Proof::add_assumption_clause (uint64_t id, int lit,
 
 void Proof::delete_clause (Clause *c) {
   LOG (c, "PROOF deleting from proof");
-  assert (clause.empty ());
+  clause.clear(); // Can be non-empty if an allocation fails during adding.
   add_literals (c);
   clause_id = c->id;
   redundant = c->redundant;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -344,8 +344,10 @@ Solver::Solver () {
   adding_constraint = false;
   _state = INITIALIZING;
   internal = new Internal ();
+  DeferDeletePtr<Internal> delete_internal (internal);
   TRACE ("init");
   external = new External (internal);
+  DeferDeletePtr<External> delete_external (external);
   STATE (CONFIGURING);
 #ifndef NTRACING
   if (tracing_api_calls_through_environment_variable_method)
@@ -370,6 +372,9 @@ Solver::Solver () {
   } else {
     tracing_nb_lidrup_env_var_method = false;
   }
+
+  delete_internal.release ();
+  delete_external.release ();
 }
 
 Solver::~Solver () {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -101,6 +101,26 @@ template <class T> void shrink_vector (std::vector<T> &v) {
   assert (v.capacity () == v.size ()); // not guaranteed though
 }
 
+// Clean-up class for bad_alloc error safety.
+
+template<typename T>
+struct DeferDeleteArray {
+  T* data;
+  DeferDeleteArray(T* t): data(t) {}
+  ~DeferDeleteArray() { delete[] data; }
+  void release() { data = nullptr; }
+  void free() { delete[] data; data = nullptr; }
+};
+
+template<typename T>
+struct DeferDeletePtr {
+  T* data;
+  DeferDeletePtr(T* t): data(t) {}
+  ~DeferDeletePtr() { delete data; }
+  void release() { data = nullptr; }
+  void free() { delete data; data = nullptr; }
+};
+
 /*------------------------------------------------------------------------*/
 
 template <class T> inline void clear_n (T *base, size_t n) {


### PR DESCRIPTION
Fixes various conditions where consistency and memory safety can't be guaranteed in case of a failed allocation.
The goal is to guarantee the CaDiCaL instance can be deallocated and no memory is leaked after std::bad_alloc has been thrown by the allocator.

The fixes correct the following problems:

- Assumptions that are invalidated (vectors that are incrementally built)
- Arena affiliation check for clauses that ignores the new arena
- Garbage collection that can't handle an inconsistent state
- Reallocations happening between updating essential pointers
- Profiling still being active after failed allocation
- Memory being leaked using manual memory management (new, delete)

ToDo:
- [x] Compilation / regression test (Tobias)
- [x] Performance regression test on cluster
- [x] Manual code review (Armin / Mathias)
- ~~[ ] Evaluation for non-x86 platforms without TSO~~ (Terminator shouldn't cause bad allocations)
- [ ] Upstreaming of memory fuzzing in Mobical (separate Pull Request) 