### PR TITLE
Adding missing #include to incproof.cpp

### DIFF
--- a/test/api/incproof.cpp
+++ b/test/api/incproof.cpp
@@ -1,5 +1,6 @@
 #include "../../src/cadical.hpp"
 
+#include <cstdlib>
 #include <string>
 
 using namespace std;


### PR DESCRIPTION
The `getenv` function is provided by `<cstdlib>`, and the fact that on some compilers it can be found through `<cstdio>` (via `cadical.hpp`) is not guaranteed by the standard.