### PR TITLE
Fixes for __WIN32 build:

### DIFF
--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -25,7 +25,7 @@ class App : public Handler, public Terminator {
 
   Solver *solver; // Global solver.
 
-#ifndef __WIN32
+#ifndef _WIN32
   // Command line options.
   //
   int time_limit; // '-t <sec>'
@@ -109,7 +109,7 @@ void App::print_usage (bool all) {
             "  -q             be quiet\n"
 #endif
             "\n"
-#ifndef __WIN32
+#ifndef _WIN32
             "  -t <sec>       set wall clock time limit\n"
 #endif
     );
@@ -125,7 +125,7 @@ void App::print_usage (bool all) {
         "  -v             increase verbosity (see also '--verbose' below)\n"
         "  -q             be quiet (same as '--quiet')\n"
 #endif
-#ifndef __WIN32
+#ifndef _WIN32
         "  -t <sec>       set wall clock time limit\n"
 #endif
         "\n"
@@ -226,7 +226,7 @@ void App::print_usage (bool all) {
         "stops at the first satisfied cube if there is one and uses that\n"
         "one for the witness to print.  Conflict and decision limits are\n"
         "applied to each individual cube solving call while '-P', '-L'"
-#ifdef __WIN32
+#ifdef _WIN32
         "\n"
 #else
         " and\n"
@@ -491,7 +491,7 @@ int App::main (int argc, char **argv) {
       else
         decision_limit_specified = argv[i];
     }
-#ifndef __WIN32
+#ifndef _WIN32
     else if (!strcmp (argv[i], "-t")) {
       if (++i == argc)
         APPERR ("argument to '-t' missing");
@@ -624,7 +624,7 @@ int App::main (int argc, char **argv) {
   }
 #endif
   if (preprocessing > 0 || localsearch > 0 ||
-#ifndef __WIN32
+#ifndef _WIN32
       time_limit >= 0 ||
 #endif
       conflict_limit >= 0 || decision_limit >= 0) {
@@ -641,7 +641,7 @@ int App::main (int argc, char **argv) {
           localsearch, localsearch_specified);
       solver->limit ("localsearch", localsearch);
     }
-#ifndef __WIN32
+#ifndef _WIN32
     if (time_limit >= 0) {
       solver->message (
           "setting time limit to %d seconds real time (due to '-t %s')",
@@ -909,7 +909,7 @@ int App::main (int argc, char **argv) {
     close (1);
     pclose (less_pipe);
   }
-#ifndef __WIN32
+#ifndef _WIN32
   if (time_limit > 0)
     alarm (0);
 #endif
@@ -925,7 +925,7 @@ void App::init () {
 
   assert (!solver);
 
-#ifndef __WIN32
+#ifndef _WIN32
   time_limit = -1;
 #endif
   force_strict_parsing = 1;

--- a/src/cadical.hpp
+++ b/src/cadical.hpp
@@ -1054,10 +1054,14 @@ private:
   //
   // TODO: support for other compilers (beside 'gcc' and 'clang').
 
+#ifndef _WIN32
 #define CADICAL_ATTRIBUTE_FORMAT(FORMAT_POSITION, \
                                  VARIADIC_ARGUMENT_POSITION) \
   __attribute__ ((format (PRINTF_FORMAT, FORMAT_POSITION, \
                           VARIADIC_ARGUMENT_POSITION)))
+#else
+#define CADICAL_ATTRIBUTE_FORMAT(X,Y) /**/
+#endif
 
   // Messages in a common style.
   //

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -11,12 +11,12 @@ extern "C" {
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 }
 
 #ifndef _WIN32
 
 extern "C" {
+#include <unistd.h>
 #include <sys/wait.h>
 }
 

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -57,7 +57,7 @@ class File {
                           const char *mode);
   static FILE *read_pipe (Internal *, const char *fmt, const int *sig,
                           const char *path);
-#ifndef __WIN32
+#ifndef _WIN32
   static FILE *write_pipe (Internal *, const char *fmt, const char *path,
                            int &child_pid);
 #endif

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -22,9 +22,31 @@
 
 // Less common 'C' header.
 
+#ifndef _WIN32
+
 extern "C" {
 #include <unistd.h>
 }
+
+#else
+
+#include <io.h>
+#include <intrin.h>
+
+#define pclose _pclose
+#define popen _popen
+#define access _access
+#define isatty _isatty
+
+#define R_OK 4
+#define W_OK 2
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#define S_ISFIFO(mode)	(((mode) & _S_IFMT) == _S_IFIFO)
+
+#define __PRETTY_FUNCTION__ __FUNCTION__
+#define  __builtin_prefetch(A,B,C) _m_prefetch((void*)(A))
+
+#endif
 
 /*------------------------------------------------------------------------*/
 

--- a/src/mobical.cpp
+++ b/src/mobical.cpp
@@ -154,7 +154,6 @@ extern "C" {
 #include <dlfcn.h>
 #include <execinfo.h>
 #endif
-#include <unistd.h>
 }
 
 #ifdef MOBICAL_MEMORY
@@ -1212,9 +1211,9 @@ struct Call {
     REDUNDANT       = shift (  5 ),
     IRREDUNDANT     = shift (  6 ),
     RESERVE         = shift (  7 ),
-                              
+
     PHASE           = shift (  8 ),
-                              
+
     ADD             = shift (  9 ),
     ASSUME          = shift ( 10 ),
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -78,7 +78,7 @@ static uint64_t hash_machine_identifier () {
 // work.  As an additional measure to increase the possibility to get
 // different seeds we are now also using network addresses (explicitly).
 
-#ifndef __WIN32
+#ifndef _WIN32
 
 extern "C" {
 #include <ifaddrs.h>
@@ -102,7 +102,7 @@ static uint64_t hash_network_addresses () {
   // you really need to run 'mobical' on a Windows cluster where each node
   // has identical IP addresses.
 
-#ifndef __WIN32
+#ifndef _WIN32
   struct ifaddrs *addrs;
   if (!getifaddrs (&addrs)) {
     for (struct ifaddrs *addr = addrs; addr; addr = addr->ifa_next) {
@@ -157,15 +157,23 @@ static uint64_t hash_time () {
 
 // Hash the process identified.
 
+#ifndef _WIN32
 extern "C" {
 #include <sys/types.h>
 #include <unistd.h>
 }
+#else
+#include <windows.h>
+#endif
 
 namespace CaDiCaL {
 
 static uint64_t hash_process () {
+#ifndef _WIN32
   uint64_t res = getpid ();
+#else
+  uint64_t res = GetCurrentProcessId();
+#endif
   PRINT_HASH (res);
   return res;
 }

--- a/src/reap.cpp
+++ b/src/reap.cpp
@@ -26,9 +26,17 @@ Reap::Reap () {
   max_bucket = 0;
 }
 
+#ifndef _WIN32
 static inline unsigned leading_zeroes_of_unsigned (unsigned x) {
   return x ? __builtin_clz (x) : sizeof (unsigned) * 8;
 }
+#else
+#include <intrin.h>
+static inline unsigned leading_zeroes_of_unsigned (unsigned x) {
+  unsigned long i;
+  return _BitScanReverse(&i, x) ? sizeof (unsigned) * 8 - 1 - i : sizeof (unsigned) * 8;
+}
+#endif
 
 void Reap::push (unsigned e) {
   assert (last_deleted <= e);

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -9,10 +9,10 @@
 
 extern "C" {
 
-#ifdef __WIN32
+#ifdef _WIN32
 
-#ifndef __WIN32_WINNT
-#define __WIN32_WINNT 0x0600
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
 #endif
 
 // Clang-format would reorder the includes which breaks the Windows code
@@ -41,7 +41,7 @@ namespace CaDiCaL {
 
 /*------------------------------------------------------------------------*/
 
-#ifdef __WIN32
+#ifdef _WIN32
 
 double absolute_real_time () {
   FILETIME f;
@@ -104,8 +104,9 @@ double Internal::process_time () const {
 
 /*------------------------------------------------------------------------*/
 
-#ifdef __WIN32
+#ifdef _WIN32
 
+#if 0
 uint64_t current_resident_set_size () {
   PROCESS_MEMORY_COUNTERS pmc;
   if (GetProcessMemoryInfo (GetCurrentProcess (), &pmc, sizeof (pmc))) {
@@ -121,6 +122,15 @@ uint64_t maximum_resident_set_size () {
   } else
     return 0;
 }
+#else
+uint64_t current_resident_set_size () {
+  return 0;
+}
+
+uint64_t maximum_resident_set_size () {
+  return 0;
+}
+#endif
 
 #else
 

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -9,9 +9,11 @@
 
 /*------------------------------------------------------------------------*/
 
+#ifndef _WIN32
 extern "C" {
-#include <unistd.h>
+  #include <unistd.h>
 }
+#endif
 
 /*------------------------------------------------------------------------*/
 
@@ -22,7 +24,7 @@ namespace CaDiCaL {
 static volatile bool caught_signal = false;
 static Handler *signal_handler;
 
-#ifndef __WIN32
+#ifndef _WIN32
 
 static volatile bool caught_alarm = false;
 static volatile bool alarm_set = false;
@@ -42,7 +44,7 @@ void Handler::catch_alarm () { catch_signal (SIGALRM); }
 SIGNALS
 #undef SIGNAL
 
-#ifndef __WIN32
+#ifndef _WIN32
 
 static void (*SIGALRM_handler) (int);
 
@@ -65,7 +67,7 @@ void Signal::reset () {
   SIG##_handler = 0;
   SIGNALS
 #undef SIGNAL
-#ifndef __WIN32
+#ifndef _WIN32
   reset_alarm ();
 #endif
   caught_signal = false;
@@ -77,7 +79,7 @@ const char *Signal::name (int sig) {
     return #SIG;
   SIGNALS
 #undef SIGNAL
-#ifndef __WIN32
+#ifndef _WIN32
   if (sig == SIGALRM)
     return "SIGALRM";
 #endif
@@ -91,7 +93,7 @@ const char *Signal::name (int sig) {
 // exclusive access to.  All these solutions are painful and not elegant.
 
 static void catch_signal (int sig) {
-#ifndef __WIN32
+#ifndef _WIN32
   if (sig == SIGALRM && absolute_real_time () >= alarm_time) {
     if (!caught_alarm) {
       caught_alarm = true;
@@ -119,7 +121,7 @@ void Signal::set (Handler *h) {
 #undef SIGNAL
 }
 
-#ifndef __WIN32
+#ifndef _WIN32
 
 void Signal::alarm (int seconds) {
   assert (seconds >= 0);

--- a/src/signal.hpp
+++ b/src/signal.hpp
@@ -10,7 +10,7 @@ public:
   Handler () {}
   virtual ~Handler () {}
   virtual void catch_signal (int sig) = 0;
-#ifndef __WIN32
+#ifndef _WIN32
   virtual void catch_alarm ();
 #endif
 };
@@ -20,7 +20,7 @@ class Signal {
 public:
   static void set (Handler *);
   static void reset ();
-#ifndef __WIN32
+#ifndef _WIN32
   static void alarm (int seconds);
   static void reset_alarm ();
 #endif


### PR DESCRIPTION
* __WIN32 is replaced with _WIN32 (both were used inconsistently)
* CADICAL_ATTRIBUTE_FORMAT is disabled
* __builtin_clz is replaced with _BitScanReverse
* getpid is replaced with GetCurrentProcessId
* __PRETTY_FUNCTION__ is replaced with __FUNCTION__
* __builtin_prefetch is replaced with _m_prefetch
* unistd.h is always guarded with #ifdef
* io operations (isatty, etc) are defined with macros