### PR TITLE
fix: remove incorrect forward-declarations

### DIFF
--- a/src/frattracer.hpp
+++ b/src/frattracer.hpp
@@ -1,6 +1,8 @@
 #ifndef _frattracer_h_INCLUDED
 #define _frattracer_h_INCLUDED
 
+#include "tracer.hpp"
+
 namespace CaDiCaL {
 
 class FratTracer : public FileTracer {

--- a/src/idruptracer.hpp
+++ b/src/idruptracer.hpp
@@ -1,7 +1,7 @@
 #ifndef _idruptracer_h_INCLUDED
 #define _idruptracer_h_INCLUDED
 
-class FileTracer;
+#include "tracer.hpp"
 
 namespace CaDiCaL {
 

--- a/src/lidruptracer.hpp
+++ b/src/lidruptracer.hpp
@@ -1,7 +1,7 @@
 #ifndef _lidruptracer_h_INCLUDED
 #define _lidruptracer_h_INCLUDED
 
-class FileTracer;
+#include "tracer.hpp"
 
 namespace CaDiCaL {
 

--- a/src/lrattracer.hpp
+++ b/src/lrattracer.hpp
@@ -1,6 +1,8 @@
 #ifndef _lrattracer_h_INCLUDED
 #define _lrattracer_h_INCLUDED
 
+#include "tracer.hpp"
+
 namespace CaDiCaL {
 
 class LratTracer : public FileTracer {

--- a/src/veripbtracer.hpp
+++ b/src/veripbtracer.hpp
@@ -1,7 +1,7 @@
 #ifndef _veripbtracer_h_INCLUDED
 #define _veripbtracer_h_INCLUDED
 
-class FileTracer;
+#include "tracer.hpp"
 
 namespace CaDiCaL {
 


### PR DESCRIPTION
This code was trying to forward-declare `CaDiCaL::FileTracer`, but was actually forward-declaring `::FileTracer`. Forward-declarations are nonsensical here anyway, as it is not legal to use forward-declarations as a base class.

Instead, this includes the header that defines the class, which is consistent with what `src/drattracer.hpp` already does.