### PR TITLE
Add getting equivalent literals

### DIFF
--- a/src/cadical.hpp
+++ b/src/cadical.hpp
@@ -883,6 +883,12 @@ public:
   bool traverse_witnesses_forward (WitnessIterator &) const;
 
   //------------------------------------------------------------------------
+  // Allows to obtain equivalent literals, where the pair (a,b) means that
+  // a == b. It is possible that (a == a) is returned.
+
+  const std::vector<std::pair<int,int>>& get_eqiv_lits () const;
+
+  //------------------------------------------------------------------------
   // Files with explicit path argument support compressed input and output
   // if appropriate helper functions 'gzip' etc. are available.  They are
   // called through opening a pipe to an external command.

--- a/src/decompose.cpp
+++ b/src/decompose.cpp
@@ -461,6 +461,9 @@ bool Internal::decompose_round () {
       proof->weaken_minus (id1, clause);
     }
     external->push_binary_clause_on_extension_stack (id1, -idx, other);
+    external->eq_lits.push_back(std::make_pair(
+      internal->externalize(idx),
+      internal->externalize(other)));
 
     decompose_ids[vlit (-idx)] = id1;
 

--- a/src/external.hpp
+++ b/src/external.hpp
@@ -59,6 +59,7 @@ struct External {
   int max_var;  // External maximum variable index.
   size_t vsize; // Allocated external size.
 
+  vector<std::pair<int, int>> eq_lits; // Stores equivalent literals
   vector<bool> vals; // Current external (extended) assignment.
   vector<int> e2i;   // External 'idx' to internal 'lit'.
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1507,6 +1507,13 @@ bool Solver::traverse_witnesses_forward (WitnessIterator &it) const {
   return res;
 }
 
+const std::vector<std::pair<int,int>>& Solver::get_eqiv_lits () const {
+  LOG_API_CALL_BEGIN ("get_eqiv_lits");
+  REQUIRE_VALID_STATE ();
+  LOG_API_CALL_RETURNS ("get_eqiv_lits", res);
+  return external->eq_lits;
+}
+
 /*------------------------------------------------------------------------*/
 
 class ClauseCounter : public ClauseIterator {


### PR DESCRIPTION
This quick hack allows one to get equivalent literals from the outside. It gathers all equivalences during decompose(), so there is some memory overhead. However, it should be small. The memory is packed (with std::pair and std::vector), so it's not too bad.

Quite useful -- sometimes after a CaDiCaL call, it can be useful to extract units, and equivalences. I use this in my version of CadiBack, for model counting. It actually helps. File `mc2024_track2-random_186.cnf.gz` when preprocessed with equivalences obtained from CadiBack:

```
c o --- [ backbone statistics ] ------------------------------------------------
c o
c o found              9009 backbones      16%
c o dropped           45860 candidates     84%
c o
c o filtered          45158 candidates     82%
c o flippable             7 candidates      0%
c o flipped               0 candidates      0%
c o fixed              8789 candidates     16%
c o core                  0 candidates      0%
c o found                 0 big_backbone   0%
c o failed                0 candidates      0%
c o
c o called solver       869 times           2%
c o satisfiable         696 times          80%
c o unsatisfiable       173 times          20%
c o
c o --- [ backbone profiling ] -------------------------------------------------
c o
c o         1.90   1.24 % first
c o         5.73   3.75 % sat
c o         2.73   1.78 % unsat
c o         1.90   1.24 % satmax
c o         1.49   0.98 % unsatmax
c o         8.46   5.53 % solving
c o         0.68   0.45 % flip
c o ====================================
c o         9.48 100.00 % total
c o
c o
c o
c o exit 10
c o [backbone-simpl] res: 10 num units added: 6500 num eq added: 180 num bins: 389 T: 14.08
```

Notice the 180 equivalent literals received.

The difference in the preprocessed CNF:
```
 804   │ c o ind size: 208 nvars: 815
...
 807   │ c o Sampling set size: 208
 808   │ c o Opt sampling set size: 815
 809   │ c o Bin irred/red      988        3698
 810   │ c o Long irred cls/tri 1391       1067
 811   │ c o Long red cls/tri   9154       3578
```

vs:

```
 801   │ c o ind size: 208 nvars: 842
...
 804   │ c o Sampling set size: 208
 805   │ c o Opt sampling set size: 842
 806   │ c o Bin irred/red      1050       4015
 807   │ c o Long irred cls/tri 1407       1077
 808   │ c o Long red cls/tri   10108      3552
```