### PR TITLE
Fix: Explicitly use signed char in congruence.cpp for ARM compatibility

### DIFF
--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -6173,7 +6173,7 @@ void Closure::rewrite_ite_gate (Gate *g, int dst, int src) {
           for (int j = 0; j < 2; ++i, ++j) {
             assert (i <= j);
             const int lit = rhs[i] = rhs[j];
-            const char v = internal->val (lit);
+            const signed char v = internal->val (lit);
             if (v > 0) {
               --i;
               negated = !negated;


### PR DESCRIPTION
I encountered a `[-Wtype-limits]` warning when building on AArch64 (Apple M3 using Ubuntu Docker):

```
../src/congruence.cpp:6046:26: warning: comparison is always false due to limited range of data type [-Wtype-limits]
 6046 |             } else if (v < 0) {
```

**The Issue:** On ARM/AArch64 architectures, char defaults to unsigned char. Consequently, if `internal->val(lit)` returns a negative value, it is cast to 255 when assigned to `const char v`. This causes the code to incorrectly enter the if `(v > 0) `branch instead of the intended negative check, and renders the `else if (v < 0)` branch dead code.

**The Fix:** I have explicitly changed the declaration to `const signed char v`. This ensures consistent behavior across x86 (signed) and ARM (unsigned), ensuring the logic remains correct on all platforms.