### PR TITLE
fix typo in argument of `get_statistic_value`

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1834,7 +1834,7 @@ int64_t Solver::get_statistic_value (const char *opt) const {
   if (!strcmp (opt, "eliminated"))
     return internal->stats.all.eliminated +
            internal->stats.all.fasteliminated;
-  if (!strcmp (opt, "subsitutued"))
+  if (!strcmp (opt, "substituted"))
     return internal->stats.all.substituted;
   return -1;
 }


### PR DESCRIPTION
While looking at the code for the new `get_statistic_value` to see what statistics are available, I noticed what I presume is a typo.