### PR TITLE
fix use-after-free in congruence closure gate table updates

### DIFF
--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -2744,8 +2744,14 @@ void Closure::update_xor_gate (Gate *g, GatesTable::iterator git) {
 void Closure::simplify_and_gate (Gate *g) {
   if (skip_and_gate (g))
     return;
-  GatesTable::iterator git = (g->indexed ? table.find (g) : end (table));
-  assert (!g->indexed || git != end (table));
+  // Remove before modifying rhs: MSVC's unordered_set::erase(iterator)
+  // recomputes the hash from the current key to fix up bucket pointers,
+  // so the erase must happen before rhs changes (unlike GCC/Clang STL).
+  if (g->indexed) {
+    table.erase (table.find (g));
+    g->indexed = false;
+  }
+  GatesTable::iterator git = end (table);
   LOG (g, "simplifying");
   int falsifies = 0;
   std::vector<int>::iterator it = begin (g->rhs);
@@ -4496,8 +4502,11 @@ void Closure::rewrite_and_gate (Gate *g, int dst, int src, LRAT_ID id1,
   assert (dst);
   assert (internal->val (src) == internal->val (dst));
   LOG (g, "rewriting %d into %d in", src, dst);
-  GatesTable::iterator git = (g->indexed ? table.find (g) : end (table));
-  assert (!g->indexed || git != table.end ());
+  if (g->indexed) {
+    table.erase (table.find (g));
+    g->indexed = false;
+  }
+  GatesTable::iterator git = end (table);
   int clashing = 0, falsifies = 0;
   unsigned dst_count = 0, not_dst_count = 0;
   auto q = begin (g->rhs);
@@ -4692,7 +4701,11 @@ void Closure::rewrite_xor_gate (Gate *g, int dst, int src) {
     return;
   LOG (g, "rewriting (%d -> %d)", src, dst);
   check_xor_gate_implied (g);
-  GatesTable::iterator git = (g->indexed ? table.find (g) : end (table));
+  if (g->indexed) {
+    table.erase (table.find (g));
+    g->indexed = false;
+  }
+  GatesTable::iterator git = end (table);
   size_t j = 0, dst_count = 0;
   bool original_dst_negated = (dst < 0);
   dst = internal->vidx (dst);
@@ -4766,7 +4779,11 @@ void Closure::simplify_xor_gate (Gate *g) {
     return;
   check_xor_gate_implied (g);
   unsigned negate = 0;
-  GatesTable::iterator git = (g->indexed ? table.find (g) : end (table));
+  if (g->indexed) {
+    table.erase (table.find (g));
+    g->indexed = false;
+  }
+  GatesTable::iterator git = end (table);
   const size_t size = g->arity ();
   size_t j = 0;
   for (size_t i = 0; i < size; ++i) {

--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -5694,9 +5694,11 @@ void Closure::rewrite_ite_gate (Gate *g, int dst, int src) {
 
   bool garbage = false;
   bool shrink = true;
-  const auto git = g->indexed ? table.find (g) : end (table);
-  assert (!g->indexed || git != end (table));
-  assert (*git == g);
+  if (g->indexed) {
+    table.erase (table.find (g));
+    g->indexed = false;
+  }
+  GatesTable::iterator git = end (table);
   if (internal->val (cond) && internal->val (then_lit) &&
       internal->val (else_lit)) { // propagation has set all value anyway
     LOG (g, "all values are set");
@@ -6637,8 +6639,11 @@ void Closure::simplify_ite_gate (Gate *g) {
       }
     } else {
       assert (!!v_then + !!v_else == 1);
-      auto git = g->indexed ? table.find (g) : end (table);
-      assert (!g->indexed || git != end (table));
+      if (g->indexed) {
+        table.erase (table.find (g));
+        g->indexed = false;
+      }
+      GatesTable::iterator git = end (table);
       if (v_then > 0) {
         g->lhs = -lhs;
         rhs[0] = -cond;
@@ -6681,7 +6686,8 @@ void Closure::simplify_ite_gate (Gate *g) {
           ++internal->stats.congruence.ites;
         }
       } else {
-        remove_gate (git);
+        if (g->indexed)
+          remove_gate (git);
         index_gate (g);
         garbage = false;
         for (auto lit : rhs)


### PR DESCRIPTION
In `simplify_and_gate`, `rewrite_and_gate`, `rewrite_xor_gate` and `simplify_xor_gate` the gate's `rhs` vector is modified before the stored iterator is passed to `update_{and,xor}_gate`, which in turn calls `remove_gate(table.erase(git))`. Because the key is changed, MSVC updates the wrong bucket, leaving a stale pointer to the freed list node in the original bucket. A subsequent `find()` on any gate that hashed to that bucket dereferences the freed node.

This is caught as a heap-use-after-free by AddressSanitizer in my Win64 port, which I compile with MSVC. Perhaps only that implementation of `unordered_set::erase(iterator)` recomputes the hash from the element's current key to find which bucket's metadata needs updating. I think GCC and Clang's STL deduce the bucket from the node's position in the list without recomputing the hash, so the bug likely does not show up there. But I still think it's better to not rely on that implementation detail. AFAIK the STL does not promise to work.

**Fix:** remove the gate from the table *before* modifying its `rhs` in all four affected functions, and pass `end(table)` to the update helpers (which already handle the `!g->indexed` case correctly).