### PR TITLE
make-build-header.sh: Respect SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/scripts/make-build-header.sh
+++ b/scripts/make-build-header.sh
@@ -83,9 +83,15 @@ fi
 #
 LC_TIME="C" # Avoid umlaut in 'DATE'.
 export LC_TIME
+
 # The time and date we compiled the CaDiCaL library.
-DATE="`date 2>/dev/null|sed -e 's,  *, ,g'`"
+# This respects the SOURCE_DATE_EPOCH, if set, for reproducible builds.
+# See <https://reproducible-builds.org/docs/source-date-epoch>.
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+BUILD_DATE=$(date -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || date -r "$SOURCE_DATE_EPOCH" 2>/dev/null || date)
+
 OS="`uname -srmn 2>/dev/null`"
+DATE="`echo $BUILD_DATE |sed -e 's,  *, ,g'`"
 DATE="`echo $DATE $OS|sed -e 's,^ *,,' -e 's, *$,,'`"
 if [ x"$DATE" = x" " ]
 then


### PR DESCRIPTION
Without this change, CaDiCaL embeds the build date into the generated shared object. Therefore, CaDiCaL is not bit-for-bit reproducible. This is a problem for Linux distribution (like Nix or Guix) which aim to enable their users to reproduce the provided binaries from source.

This patch fixes this issue by, when defined, respecting the SOURCE_DATE_EPOCH which specifies a fixed time in seconds since the Unix epoch.

See: <https://reproducible-builds.org/docs/source-date-epoch>

WDYT?