### PR TITLE
ported new signal handling to 3.0.1

### DIFF
--- a/src/backbone.cpp
+++ b/src/backbone.cpp
@@ -521,6 +521,8 @@ void Internal::keep_backbone_candidates (
 
 unsigned Internal::compute_backbone () {
   size_t failed = 0;
+  if (terminated_asynchronously ())
+    return failed;
 
   int64_t ticks = 0;
   backbone_propagate2 (ticks);
@@ -600,6 +602,8 @@ void Internal::binary_clauses_backbone () {
   if (unsat)
     return;
   if (!opts.backbone)
+    return;
+  if (terminated_asynchronously ())
     return;
   if (level)
     backtrack_without_updating_phases ();

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -49,7 +49,7 @@ class App : public Handler, public Terminator {
   //
   int max_var;           // Set after parsing.
   volatile bool timesup; // Asynchronous termination.
-
+  volatile sig_atomic_t signal_value = 0; // Caught signal.
   // Printing.
   //
   void print_usage (bool all = false);
@@ -278,8 +278,8 @@ void App::print_witness (FILE *file) {
       continue;
     else
       tmp = solver->val (i) < 0 ? -i : i;
-    // This only terminates if a signal is raised 
-    solver->internal->terminated_asynchronously (); 
+    if (signal_value) // SIGTODO: review
+      break;
     char str[32];
     snprintf (str, sizeof str, " %d", tmp);
     int l = strlen (str);
@@ -934,6 +934,13 @@ int App::main (int argc, char **argv) {
   if (time_limit > 0)
     alarm (0);
 #endif
+  // SIGTODO: Review. Just before we return from App::main
+  if (signal_value) {
+    CaDiCaL::Signal::reset ();
+    signal_message ("raising", signal_value);
+    solver->internal->report ('!'); // SIGTODO: remove after latency debugging
+    raise (signal_value);
+  }
 
   return res;
 }
@@ -989,7 +996,10 @@ void App::signal_message (const char *msg, int sig) {
 #endif
 
 void App::catch_signal (int sig) {
-  Signal::set_received (sig);
+  signal_value = sig;
+  solver->internal->report ('!'); // SIGTODO: remove after latency debugging
+  solver->internal->termination_forced = true;
+  Signal::reset (); // Send signal again -> instant termination but no stats
 }
 
 void App::catch_alarm () {

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -1010,7 +1010,7 @@ void App::signal_message (const char *msg, int sig) {
 
 void App::catch_signal (int sig) {
   signal_value = sig;
-  solver->internal->report ('!'); // SIGTODO: remove after latency debugging
+  //solver->internal->report ('!'); // SIGTODO: remove after latency debugging
   solver->internal->termination_forced = true;
   Signal::reset (); // Send signal again -> instant termination but no stats
 }

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -1007,6 +1007,7 @@ void App::catch_alarm () {
 #if 0 // THIS IS AN ALTERNATIVE WE WANT TO KEEP AROUND.
   solver->terminate (); // Immediate asynchronous call into solver.
 #else
+  solver->internal->report ('!'); // SIGTODO: remove after latency debugging
   timesup = true; // Wait for solver to call 'App::terminate ()'.
 #endif
 }

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -1020,7 +1020,7 @@ void App::catch_alarm () {
 #if 0 // THIS IS AN ALTERNATIVE WE WANT TO KEEP AROUND.
   solver->terminate (); // Immediate asynchronous call into solver.
 #else
-  solver->internal->report ('!'); // SIGTODO: remove after latency debugging
+  //solver->internal->report ('!'); // SIGTODO: remove after latency debugging
   timesup = true; // Wait for solver to call 'App::terminate ()'.
 #endif
 }

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -278,6 +278,8 @@ void App::print_witness (FILE *file) {
       continue;
     else
       tmp = solver->val (i) < 0 ? -i : i;
+    // This only terminates if a signal is raised 
+    solver->internal->terminated_asynchronously (); 
     char str[32];
     snprintf (str, sizeof str, " %d", tmp);
     int l = strlen (str);
@@ -714,10 +716,13 @@ int App::main (int argc, char **argv) {
   if (dimacs_path)
     err = solver->read_dimacs (dimacs_path, max_var, force_strict_parsing,
                                incremental, cube_literals);
-  else
+  else {
+    Signal::reset ();
     err = solver->read_dimacs (stdin, dimacs_name, max_var,
                                force_strict_parsing, incremental,
                                cube_literals);
+    Signal::set (this);
+  }
   if (err)
     APPERR ("%s", err);
   if (read_solution_path) {
@@ -984,20 +989,7 @@ void App::signal_message (const char *msg, int sig) {
 #endif
 
 void App::catch_signal (int sig) {
-#ifndef QUIET
-  if (!get ("quiet")) {
-    solver->message ();
-    signal_message ("caught", sig);
-    solver->section ("result");
-    solver->message ("UNKNOWN");
-    solver->statistics ();
-    solver->resources ();
-    solver->message ();
-    signal_message ("raising", sig);
-  }
-#else
-  (void) sig;
-#endif
+  Signal::set_received (sig);
 }
 
 void App::catch_alarm () {

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -278,7 +278,7 @@ void App::print_witness (FILE *file) {
       continue;
     else
       tmp = solver->val (i) < 0 ? -i : i;
-    if (signal_value) // SIGTODO: review
+    if (signal_value)
       break;
     char str[32];
     snprintf (str, sizeof str, " %d", tmp);
@@ -653,7 +653,6 @@ int App::main (int argc, char **argv) {
           localsearch, localsearch_specified);
       solver->limit ("localsearch", localsearch);
     }
-    /* SIGTODO: uncomment this block
 #ifndef _WIN32
     if (time_limit >= 0) {
       solver->message (
@@ -663,7 +662,6 @@ int App::main (int argc, char **argv) {
       solver->connect_terminator (this);
     }
 #endif
-*/
     if (conflict_limit >= 0) {
       solver->message (
           "setting conflict limit to %d conflicts (due to '%s')",
@@ -727,17 +725,6 @@ int App::main (int argc, char **argv) {
   }
   if (err)
     APPERR ("%s", err);
-  // SIGTODO: remove this block. Just here for better latency testing
-  #ifndef _WIN32
-    if (time_limit >= 0) {
-      solver->message (
-          "setting time limit to %d seconds real time (due to '-t %s')",
-          time_limit, time_limit_specified);
-      Signal::alarm (time_limit);
-      solver->connect_terminator (this);
-    }
-  #endif
-  // ----------
   if (read_solution_path) {
     solver->section ("parsing solution");
     solver->message ("reading solution file from '%s'", read_solution_path);
@@ -947,11 +934,10 @@ int App::main (int argc, char **argv) {
   if (time_limit > 0)
     alarm (0);
 #endif
-  // SIGTODO: Review. Just before we return from App::main
+
   if (signal_value) {
     CaDiCaL::Signal::reset ();
     signal_message ("raising", signal_value);
-    solver->internal->report ('!'); // SIGTODO: remove after latency debugging
     raise (signal_value);
   }
 
@@ -1010,7 +996,6 @@ void App::signal_message (const char *msg, int sig) {
 
 void App::catch_signal (int sig) {
   signal_value = sig;
-  //solver->internal->report ('!'); // SIGTODO: remove after latency debugging
   solver->internal->termination_forced = true;
   Signal::reset (); // Send signal again -> instant termination but no stats
 }
@@ -1020,8 +1005,8 @@ void App::catch_alarm () {
 #if 0 // THIS IS AN ALTERNATIVE WE WANT TO KEEP AROUND.
   solver->terminate (); // Immediate asynchronous call into solver.
 #else
-  //solver->internal->report ('!'); // SIGTODO: remove after latency debugging
-  timesup = true; // Wait for solver to call 'App::terminate ()'.
+  solver->internal->termination_forced = true;
+  // timesup = true; // Wait for solver to call 'App::terminate ()'.
 #endif
 }
 

--- a/src/cadical.cpp
+++ b/src/cadical.cpp
@@ -653,6 +653,7 @@ int App::main (int argc, char **argv) {
           localsearch, localsearch_specified);
       solver->limit ("localsearch", localsearch);
     }
+    /* SIGTODO: uncomment this block
 #ifndef _WIN32
     if (time_limit >= 0) {
       solver->message (
@@ -662,6 +663,7 @@ int App::main (int argc, char **argv) {
       solver->connect_terminator (this);
     }
 #endif
+*/
     if (conflict_limit >= 0) {
       solver->message (
           "setting conflict limit to %d conflicts (due to '%s')",
@@ -725,6 +727,17 @@ int App::main (int argc, char **argv) {
   }
   if (err)
     APPERR ("%s", err);
+  // SIGTODO: remove this block. Just here for better latency testing
+  #ifndef _WIN32
+    if (time_limit >= 0) {
+      solver->message (
+          "setting time limit to %d seconds real time (due to '-t %s')",
+          time_limit, time_limit_specified);
+      Signal::alarm (time_limit);
+      solver->connect_terminator (this);
+    }
+  #endif
+  // ----------
   if (read_solution_path) {
     solver->section ("parsing solution");
     solver->message ("reading solution file from '%s'", read_solution_path);

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -896,6 +896,8 @@ void Internal::condition (bool update_limits) {
 
   if (unsat)
     return;
+  if (terminated_asynchronously ())
+    return;
   if (!stats.current.irredundant)
     return;
 

--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -202,6 +202,8 @@ bool Closure::find_binary (int lit, int other) const {
 void Closure::extract_binaries () {
   if (!internal->opts.congruencebinaries)
     return;
+  if (internal->terminated_asynchronously ())
+    return;
   START (extractbinaries);
   offsetsize.resize (internal->max_var * 2 + 3, make_pair (0, 0));
 
@@ -214,6 +216,10 @@ void Closure::extract_binaries () {
       continue;
     if (c->size > 2)
       continue;
+    if (internal->terminated_asynchronously ()) {
+      STOP(extractbinaries);
+      return;
+    }
     assert (c->size == 2);
     const int lit = c->literals[0];
     const int other = c->literals[1];
@@ -223,7 +229,10 @@ void Closure::extract_binaries () {
                                        already_sorted ? lit : other,
                                        already_sorted ? other : lit));
   }
-
+  if (internal->terminated_asynchronously ()) {
+    STOP (extractbinaries);
+    return;
+  }
   MSORT (internal->opts.radixsortlim, begin (binaries), end (binaries),
          compact_binary_rank (internal), compact_binary_order (internal));
 
@@ -249,6 +258,10 @@ void Closure::extract_binaries () {
 
   const size_t size = internal->clauses.size ();
   for (size_t i = 0; i < size; ++i) {
+    if (internal->terminated_asynchronously ()) {
+      STOP (extractbinaries);
+      return;
+    }
     Clause *d = internal->clauses[i]; // binary clauses are appended, so
                                       // reallocation possible
     if (d->garbage)
@@ -295,6 +308,10 @@ void Closure::extract_binaries () {
 
   // kissat has code to remove duplicates, which we have already removed
   // before starting congruence
+  if (internal->terminated_asynchronously ()) {
+    STOP (extractbinaries);
+    return;
+  }
   MSORT (internal->opts.radixsortlim, begin (binaries), end (binaries),
          compact_binary_rank (internal), compact_binary_order (internal));
   const size_t new_size = binaries.size ();
@@ -3399,6 +3416,8 @@ void Closure::extract_and_gates () {
   assert (!full_watching);
   if (!internal->opts.congruenceand)
     return;
+  if (internal->terminated_asynchronously ())
+    return;
   START (extractands);
 
   marks.resize (internal->max_var * 2 + 3);
@@ -4129,6 +4148,8 @@ void Closure::init_xor_gate_extraction (std::vector<Clause *> &candidates) {
   }
 
   for (auto c : candidates) {
+    if (internal->terminated_asynchronously ())
+      return;
     for (auto lit : *c)
       internal->occs (lit).push_back (c);
   }
@@ -4345,6 +4366,10 @@ void Closure::extract_xor_gates () {
   for (auto c : candidates) {
     if (internal->unsat)
       break;
+    if (internal->terminated_asynchronously ()) {
+      STOP (extractxors);
+      return;
+    }
     if (c->garbage)
       continue;
     extract_xor_gates_with_base_clause (c);
@@ -4358,6 +4383,8 @@ void Closure::extract_xor_gates () {
 
 /*------------------------------------------------------------------------*/
 void Closure::find_units () {
+  if (internal->terminated_asynchronously ())
+    return;
   size_t units = 0;
   for (auto v : internal->vars) {
   RESTART:
@@ -4400,7 +4427,8 @@ void Closure::find_units () {
 
 void Closure::find_equivalences () {
   assert (!internal->unsat);
-
+  if (internal->terminated_asynchronously ())
+    return;
   for (auto v : internal->vars) {
   RESTART:
     if (!internal->flags (v).active ())
@@ -4846,6 +4874,8 @@ bool Closure::propagate_equivalence (int lit) {
 }
 
 size_t Closure::propagate_units_and_equivalences () {
+  if (internal->terminated_asynchronously ())
+    return 0;
   START (congruencemerge);
   size_t propagated = 0;
   LOG ("propagating at least %zd units", schedule.size ());
@@ -7235,6 +7265,8 @@ void Closure::init_ite_gate_extraction (
   for (auto c : ternary) {
     assert (!c->garbage);
     assert (!c->redundant);
+    if (internal->terminated_asynchronously ())
+      break;
     unsigned positive = 0, negative = 0, twice = 0;
     for (auto lit : *c) {
       if (internal->val (lit))
@@ -7692,7 +7724,7 @@ void Closure::extract_ite_gates () {
   for (auto idx : internal->vars) {
     if (internal->flags (idx).active ()) {
       extract_ite_gates_of_variable (idx);
-      if (internal->unsat)
+      if (internal->unsat || internal->terminated_asynchronously ())
         break;
     }
   }
@@ -7740,6 +7772,8 @@ void Closure::extract_gates () {
 /*------------------------------------------------------------------------*/
 // top level function to extract gate
 bool Internal::extract_gates (bool remove_units_before_run) {
+  if (terminated_asynchronously ())
+    return false;
   if (unsat)
     return false;
   if (!opts.congruence)
@@ -7799,21 +7833,22 @@ bool Internal::extract_gates (bool remove_units_before_run) {
   closure.extract_gates ();
   assert (unsat || closure.chain.empty ());
   assert (unsat || lrat_chain.empty ());
-  closure.reset_extraction ();
+  if (!internal->terminated_asynchronously ())
+    closure.reset_extraction ();
 
-  if (!unsat) {
+  if (!unsat && !internal->terminated_asynchronously ()) {
     closure.find_units ();
     assert (unsat || closure.chain.empty ());
     assert (unsat || lrat_chain.empty ());
-    if (!internal->unsat) {
+    if (!internal->unsat && !internal->terminated_asynchronously ()) {
       closure.find_equivalences ();
       assert (unsat || closure.chain.empty ());
       assert (unsat || lrat_chain.empty ());
 
-      if (!unsat) {
+      if (!unsat && !internal->terminated_asynchronously ()) {
         const int propagated = closure.propagate_units_and_equivalences ();
         assert (unsat || closure.chain.empty ());
-        if (!unsat && propagated)
+        if (!unsat && propagated && !internal->terminated_asynchronously ())
           closure.forward_subsume_matching_clauses ();
       }
     }
@@ -7825,7 +7860,7 @@ bool Internal::extract_gates (bool remove_units_before_run) {
   if (!internal->unsat) {
     propagated2 = propagated = 0;
   }
-  assert (closure.new_unwatched_binary_clauses.empty ());
+  assert (closure.new_unwatched_binary_clauses.empty () || internal->terminated_asynchronously ());
   internal->reset_occs ();
   internal->reset_noccs ();
   assert (!internal->occurring ());

--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -4881,6 +4881,8 @@ size_t Closure::propagate_units_and_equivalences () {
   LOG ("propagating at least %zd units", schedule.size ());
   assert (lrat_chain.empty ());
   while (propagate_units () && !schedule.empty ()) {
+    if (internal->terminated_asynchronously ())
+      return 0;
     assert (!internal->unsat);
     assert (lrat_chain.empty ());
     ++propagated;

--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -7872,7 +7872,7 @@ bool Internal::extract_gates (bool remove_units_before_run) {
 
   PHASE ("congruence-phase", stats.congruence.rounds,
          "merged %" PRId64 " literals", new_merged - old_merged);
-  if (!unsat && !internal->propagate ()) {
+  if (!internal->terminated_asynchronously () && !unsat && !internal->propagate ()) {
     learn_empty_clause ();
   }
 

--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -4356,6 +4356,8 @@ void Closure::extract_xor_gates () {
   assert (!full_watching);
   if (!internal->opts.congruencexor)
     return;
+  if (internal->terminated_asynchronously ())
+    return;
   START (extractxors);
 #ifndef QUIET
   const int64_t gates_before = internal->stats.congruence.xor_gates;
@@ -7716,6 +7718,8 @@ void Closure::extract_ite_gates () {
   assert (!full_watching);
   if (!internal->opts.congruenceite)
     return;
+  if (internal->terminated_asynchronously ())
+    return;
   START (extractites);
   std::vector<ClauseSize> candidates;
 #ifndef QUIET
@@ -7758,7 +7762,6 @@ void Closure::extract_gates () {
     assert (mu2_ids.empty ());
     assert (mu4_ids.empty ());
   }
-
   extract_xor_gates ();
   assert (internal->unsat || lrat_chain.empty ());
   assert (internal->unsat || chain.empty ());
@@ -7819,7 +7822,6 @@ bool Internal::extract_gates (bool remove_units_before_run) {
   ++stats.congruence.rounds;
   clear_watches ();
   //  connect_binary_watches ();
-
   START_SIMPLIFIER (congruence, CONGRUENCE);
   Closure closure (this);
 
@@ -7835,8 +7837,11 @@ bool Internal::extract_gates (bool remove_units_before_run) {
   closure.extract_gates ();
   assert (unsat || closure.chain.empty ());
   assert (unsat || lrat_chain.empty ());
-  if (!internal->terminated_asynchronously ())
-    closure.reset_extraction ();
+  bool reconnect = true;
+  if (!internal->terminated_asynchronously ()) {
+    closure.reset_extraction (); // reconnect watches
+    reconnect = false; // fresh watches
+  }
 
   if (!unsat && !internal->terminated_asynchronously ()) {
     closure.find_units ();
@@ -7854,11 +7859,13 @@ bool Internal::extract_gates (bool remove_units_before_run) {
           closure.forward_subsume_matching_clauses ();
       }
     }
+    reconnect = true; // possibly stale watches
   }
-
-  closure.reset_closure ();
-  internal->clear_watches ();
-  internal->connect_watches ();
+  closure.reset_closure (); 
+  if (reconnect) {
+    internal->clear_watches ();
+    internal->connect_watches ();  
+  }
   if (!internal->unsat) {
     propagated2 = propagated = 0;
   }
@@ -7867,7 +7874,6 @@ bool Internal::extract_gates (bool remove_units_before_run) {
   internal->reset_noccs ();
   assert (!internal->occurring ());
   assert (lrat_chain.empty ());
-
   const int64_t new_merged = stats.congruence.congruent;
 
   PHASE ("congruence-phase", stats.congruence.rounds,

--- a/src/decompose.cpp
+++ b/src/decompose.cpp
@@ -176,6 +176,10 @@ bool Internal::decompose_round () {
     if (!active (root_idx))
       continue;
     for (int root_sign = -1; !unsat && root_sign <= 1; root_sign += 2) {
+      if (terminated_asynchronously ()) {
+        STOP_SIMPLIFIER (decompose, DECOMP);
+        return false;
+      }
       int root = root_sign * root_idx;
       if (dfs[vlit (root)].min == TRAVERSED)
         continue; // skip traversed

--- a/src/elim.cpp
+++ b/src/elim.cpp
@@ -675,7 +675,6 @@ void Internal::mark_eliminated_clauses_as_garbage (
 // Try to eliminate 'pivot' by bounded variable elimination.
 void Internal::try_to_eliminate_variable (Eliminator &eliminator, int pivot,
                                           bool &deleted_binary_clause) {
-
   if (!active (pivot))
     return;
   assert (!frozen (pivot));
@@ -860,11 +859,14 @@ int Internal::elim_round (bool &completed, bool &deleted_binary_clause) {
 
   // Connect irredundant clauses.
   //
-  for (const auto &c : clauses)
+  for (const auto &c : clauses) {
+    if (terminated_asynchronously ())
+      break;
     if (!c->garbage && !c->redundant)
       for (const auto &lit : *c)
-        if (active (lit))
-          occs (lit).push_back (c);
+        if (active (lit)) 
+          occs (lit).push_back (c); 
+  }
 
 #ifndef QUIET
   const int64_t old_resolutions = stats.elimres;

--- a/src/elim.cpp
+++ b/src/elim.cpp
@@ -1018,6 +1018,8 @@ void Internal::elim (bool update_limits) {
 
   if (unsat)
     return;
+  if (terminated_asynchronously ())
+    return;
   if (level)
     backtrack ();
   if (!propagate ()) {

--- a/src/elimfast.cpp
+++ b/src/elimfast.cpp
@@ -95,6 +95,8 @@ bool Internal::elimfast_resolvents_are_bounded (Eliminator &eliminator,
   int64_t resolvents = 0; // Non-tautological resolvents.
 
   for (const auto &c : ps) {
+    if (terminated_asynchronously ())
+      return false;
     assert (!c->redundant);
     if (c->garbage)
       continue;
@@ -122,6 +124,8 @@ bool Internal::elimfast_resolvents_are_bounded (Eliminator &eliminator,
       } else if (unsat)
         return false;
       else if (val (pivot))
+        return false;
+      else if (terminated_asynchronously ())
         return false;
     }
   }
@@ -267,6 +271,8 @@ int Internal::elimfast_round (bool &completed,
 
   assert (opts.fastelim);
   assert (!unsat);
+  if (terminated_asynchronously ())
+    return 0;
 
   START_SIMPLIFIER (fastelim, ELIM);
 
@@ -300,6 +306,8 @@ int Internal::elimfast_round (bool &completed,
   // clauses with root level assigned literals (both false and true).
   //
   for (const auto &c : clauses) {
+    if (terminated_asynchronously ())
+      break;
     if (c->garbage || c->redundant)
       continue;
     bool satisfied = false, falsified = false;
@@ -358,12 +366,15 @@ int Internal::elimfast_round (bool &completed,
 
   // Connect irredundant clauses.
   //
-  for (const auto &c : clauses)
+  for (const auto &c : clauses) {
+    if (terminated_asynchronously ())
+      break;
     if (!c->garbage && !c->redundant)
       for (const auto &lit : *c)
         if (active (lit))
           occs (lit).push_back (c);
-
+  }
+  
 #ifndef QUIET
   const int64_t old_resolutions = stats.elimres;
 #endif
@@ -438,6 +449,8 @@ int Internal::elimfast_round (bool &completed,
 void Internal::elimfast () {
 
   if (unsat)
+    return;
+  if (terminated_asynchronously ())
     return;
   if (level)
     backtrack ();

--- a/src/external.cpp
+++ b/src/external.cpp
@@ -822,6 +822,8 @@ void External::check_constraint_satisfied () {
 
 void External::check_failing () {
   Solver *checker = new Solver ();
+  if (terminator)
+    checker->connect_terminator (terminator); // SIGTODO: review.
   DeferDeletePtr<Solver> delete_checker (checker);
   checker->prefix ("checker ");
 #ifdef LOGGING

--- a/src/external.cpp
+++ b/src/external.cpp
@@ -823,7 +823,7 @@ void External::check_constraint_satisfied () {
 void External::check_failing () {
   Solver *checker = new Solver ();
   if (terminator)
-    checker->connect_terminator (terminator); // SIGTODO: review.
+    checker->connect_terminator (terminator);
   DeferDeletePtr<Solver> delete_checker (checker);
   checker->prefix ("checker ");
 #ifdef LOGGING

--- a/src/factor.cpp
+++ b/src/factor.cpp
@@ -38,6 +38,8 @@ void Internal::factor_mode () {
   // push binary clauses on the occurrence stack.
   for (const auto &c : clauses) {
     ticks++;
+    if (terminated_asynchronously ())
+      return;
     if (c->garbage)
       continue;
     if (c->redundant && c->size > 2)
@@ -65,6 +67,8 @@ void Internal::factor_mode () {
   const unsigned rounds = opts.factorcandrounds;
   unsigned candidates_before = 0;
   for (unsigned round = 1; round <= rounds; round++) {
+    if (terminated_asynchronously ())
+      return;
     LOG ("factor round %d", round);
     if (candidates.size () == candidates_before)
       break;
@@ -98,9 +102,12 @@ void Internal::factor_mode () {
   }
 
   // finally push remaining clause on the occurrence stack
-  for (const auto &c : candidates)
+  for (const auto &c : candidates) {
+    if (terminated_asynchronously ())
+      return;
     for (const auto &lit : *c)
       occs (lit).push_back (c);
+  }
 }
 
 // go back to two watch scheme

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -702,6 +702,8 @@ bool Internal::preprocess_round (int round) {
     return false;
   if (!max_var)
     return false;
+  if (terminated_asynchronously ())
+    return false;
   START (preprocess);
   struct {
     int64_t vars, clauses;
@@ -747,6 +749,8 @@ void Internal::preprocess_quickly (bool always) {
   if (unsat)
     return;
   if (!max_var)
+    return;
+  if (terminated_asynchronously ())
     return;
   if (!opts.preprocesslight)
     return;

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -1863,33 +1863,6 @@ inline int External::fixed (int elit) const {
 // data race issue (it also has been declared 'volatile').
 
 inline bool Internal::terminated_asynchronously (int factor) {
-  // Here we check whether a signal was caught. 
-  // We will immediately reraise after printing stats. For this we need to move
-  // this above the 'if (termination_forced)' branch.
-  /* SIGTODO: Evil dependency. Needs to be removed
-  if (const int sig = Signal::received ()) {
-    VERBOSE (2, "signal %d detected", sig);
-#ifndef QUIET
-    if (!opts.quiet) {
-      message ();
-      message ("%s%s %ssignal %d%s (%s)%s", tout.red_code (), "caught",
-                tout.bright_red_code (), sig, tout.red_code (),
-                Signal::name (sig), tout.normal_code ());
-      section ("result");
-      message ("UNKNOWN");
-      print_statistics ();
-      print_resource_usage ();
-      message ();
-      message ("%s%s %ssignal %d%s (%s)%s", tout.red_code (), "raising",
-                tout.bright_red_code (), sig, tout.red_code (),
-                Signal::name (sig), tout.normal_code ());
-    }
-#endif
-
-    Signal::reset (); // Disconnects signal handler
-    raise (sig);
-  }
-  */
   // First way of asynchronous termination is through 'terminate' or 
   // 'catch_signal' which sets the 'termination_forced' flag directly.  
   // The second way is through a call back to a 'terminator' if it is non-zero,

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -93,6 +93,7 @@ extern "C" {
 #include "reluctant.hpp"
 #include "resources.hpp"
 #include "score.hpp"
+#include "signal.hpp"
 #include "stats.hpp"
 #include "sweep.hpp"
 #include "terminal.hpp"
@@ -1863,6 +1864,31 @@ inline int External::fixed (int elit) const {
 // data race issue (it also has been declared 'volatile').
 
 inline bool Internal::terminated_asynchronously (int factor) {
+  // Here we check whether a signal was caught. 
+  // We will immediately reraise after printing stats. For this we need to move
+  // this above the 'if (termination_forced)' branch.
+  if (const int sig = Signal::received ()) {
+    VERBOSE (2, "signal %d detected", sig);
+#ifndef QUIET
+    if (!opts.quiet) {
+      message ();
+      message ("%s%s %ssignal %d%s (%s)%s", tout.red_code (), "caught",
+                tout.bright_red_code (), sig, tout.red_code (),
+                Signal::name (sig), tout.normal_code ());
+      section ("result");
+      message ("UNKNOWN");
+      print_statistics ();
+      print_resource_usage ();
+      message ();
+      message ("%s%s %ssignal %d%s (%s)%s", tout.red_code (), "raising",
+                tout.bright_red_code (), sig, tout.red_code (),
+                Signal::name (sig), tout.normal_code ());
+    }
+#endif
+
+    Signal::reset (); // Disconnects signal handler
+    raise (sig);
+  }
   // First way of asynchronous termination is through 'terminate' which sets
   // the 'termination_forced' flag directly.  The second way is through a
   // call back to a 'terminator' if it is non-zero, which however is costly.

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -93,7 +93,6 @@ extern "C" {
 #include "reluctant.hpp"
 #include "resources.hpp"
 #include "score.hpp"
-#include "signal.hpp"
 #include "stats.hpp"
 #include "sweep.hpp"
 #include "terminal.hpp"
@@ -1867,6 +1866,7 @@ inline bool Internal::terminated_asynchronously (int factor) {
   // Here we check whether a signal was caught. 
   // We will immediately reraise after printing stats. For this we need to move
   // this above the 'if (termination_forced)' branch.
+  /* SIGTODO: Evil dependency. Needs to be removed
   if (const int sig = Signal::received ()) {
     VERBOSE (2, "signal %d detected", sig);
 #ifndef QUIET
@@ -1889,9 +1889,11 @@ inline bool Internal::terminated_asynchronously (int factor) {
     Signal::reset (); // Disconnects signal handler
     raise (sig);
   }
-  // First way of asynchronous termination is through 'terminate' which sets
-  // the 'termination_forced' flag directly.  The second way is through a
-  // call back to a 'terminator' if it is non-zero, which however is costly.
+  */
+  // First way of asynchronous termination is through 'terminate' or 
+  // 'catch_signal' which sets the 'termination_forced' flag directly.  
+  // The second way is through a call back to a 'terminator' if it is non-zero,
+  // which however is costly.
   //
   if (termination_forced) {
     LOG ("termination asynchronously forced");

--- a/src/lucky.cpp
+++ b/src/lucky.cpp
@@ -497,6 +497,11 @@ int Internal::lucky_phases () {
     LOG ("lucky %" PRId64 " units", units);
   searching_lucky_phases = false;
 
+  // Here we should reset lim.terminate.check since in a lucky run this 
+  // may be set to up to 1000. This then may lead to a high latency for external
+  // termination.
+  lim.terminate.check = opts.terminateint;
+
   STOP (lucky);
   STOP (search);
 

--- a/src/lucky.cpp
+++ b/src/lucky.cpp
@@ -28,6 +28,8 @@ int Internal::unlucky (int res) {
 }
 
 int Internal::trivially_false_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking that all clauses contain a negative literal");
   assert (!level);
   int res = lucky_decide_assumptions ();
@@ -77,6 +79,8 @@ int Internal::trivially_false_satisfiable () {
 }
 
 int Internal::trivially_true_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking that all clauses contain a positive literal");
   assert (!level);
   int res = lucky_decide_assumptions ();
@@ -153,6 +157,8 @@ inline bool Internal::lucky_propagate_discrepency (int dec) {
 }
 
 int Internal::forward_false_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking increasing variable index false assignment");
   assert (!unsat);
   assert (!level);
@@ -180,6 +186,8 @@ int Internal::forward_false_satisfiable () {
 }
 
 int Internal::forward_true_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking increasing variable index true assignment");
   assert (!unsat);
   assert (!level);
@@ -209,6 +217,8 @@ int Internal::forward_true_satisfiable () {
 /*------------------------------------------------------------------------*/
 
 int Internal::backward_false_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking decreasing variable index false assignment");
   assert (!unsat);
   assert (!level);
@@ -237,6 +247,8 @@ int Internal::backward_false_satisfiable () {
 }
 
 int Internal::backward_true_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking decreasing variable index true assignment");
   assert (!unsat);
   assert (!level);
@@ -273,6 +285,8 @@ int Internal::backward_true_satisfiable () {
 // is not implemented yet.
 
 int Internal::positive_horn_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   LOG ("checking that all clauses are positive horn satisfiable");
   assert (!level);
   int res = lucky_decide_assumptions ();
@@ -372,6 +386,8 @@ int Internal::lucky_decide_assumptions () {
 }
 
 int Internal::negative_horn_satisfiable () {
+  if (terminated_asynchronously ())
+    return -1; // SIGTODO: review
   assert (!level);
   LOG ("checking that all clauses are negative horn satisfiable");
   int res = lucky_decide_assumptions ();
@@ -441,8 +457,9 @@ int Internal::lucky_phases () {
   require_mode (SEARCH);
   if (!opts.lucky)
     return 0;
-
   if (!opts.luckyassumptions && !assumptions.empty ())
+    return 0;
+  if (terminated_asynchronously ())
     return 0;
   // TODO: Some of the lucky assignments can also be found if there are
   // constraint.

--- a/src/lucky.cpp
+++ b/src/lucky.cpp
@@ -29,7 +29,7 @@ int Internal::unlucky (int res) {
 
 int Internal::trivially_false_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking that all clauses contain a negative literal");
   assert (!level);
   int res = lucky_decide_assumptions ();
@@ -80,7 +80,7 @@ int Internal::trivially_false_satisfiable () {
 
 int Internal::trivially_true_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking that all clauses contain a positive literal");
   assert (!level);
   int res = lucky_decide_assumptions ();
@@ -158,7 +158,7 @@ inline bool Internal::lucky_propagate_discrepency (int dec) {
 
 int Internal::forward_false_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking increasing variable index false assignment");
   assert (!unsat);
   assert (!level);
@@ -187,7 +187,7 @@ int Internal::forward_false_satisfiable () {
 
 int Internal::forward_true_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking increasing variable index true assignment");
   assert (!unsat);
   assert (!level);
@@ -218,7 +218,7 @@ int Internal::forward_true_satisfiable () {
 
 int Internal::backward_false_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking decreasing variable index false assignment");
   assert (!unsat);
   assert (!level);
@@ -248,7 +248,7 @@ int Internal::backward_false_satisfiable () {
 
 int Internal::backward_true_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking decreasing variable index true assignment");
   assert (!unsat);
   assert (!level);
@@ -286,7 +286,7 @@ int Internal::backward_true_satisfiable () {
 
 int Internal::positive_horn_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   LOG ("checking that all clauses are positive horn satisfiable");
   assert (!level);
   int res = lucky_decide_assumptions ();
@@ -387,7 +387,7 @@ int Internal::lucky_decide_assumptions () {
 
 int Internal::negative_horn_satisfiable () {
   if (terminated_asynchronously ())
-    return -1; // SIGTODO: review
+    return -1;
   assert (!level);
   LOG ("checking that all clauses are negative horn satisfiable");
   int res = lucky_decide_assumptions ();

--- a/src/mobical.cpp
+++ b/src/mobical.cpp
@@ -186,8 +186,15 @@ void initialize_allocators () {
   libc_realloc = reinterpret_cast<realloc_t> (dlsym (RTLD_NEXT, "realloc"));
   libc_free = reinterpret_cast<free_t> (dlsym (RTLD_NEXT, "free"));
 }
-__attribute__ ((section (".preinit_array"))) void (*init_allocators_ptr) (
-    void) = initialize_allocators;
+//__attribute__ ((section (".preinit_array"))) void (*init_allocators_ptr) (
+//    void) = initialize_allocators;
+// REVIEW: ^^ this does not work on apple ^^ vv this seemed to work vv
+#ifdef __APPLE__
+__attribute__ ((section ("__DATA,__mod_init_func")))
+#else
+__attribute__ ((section (".preinit_array")))
+#endif
+void (*init_allocators_ptr)(void) = initialize_allocators;
 #endif
 
 /*------------------------------------------------------------------------*/
@@ -2056,7 +2063,8 @@ public:
   SIGNAL (SIGTERM) \
   SIGNAL (SIGBUS) \
   SIGNAL (SIGUSR1) \
-  SIGNAL (SIGUSR2)
+  SIGNAL (SIGUSR2) \
+  SIGNAL (SIGTSTP)
 
 #define SIGNAL(SIG) static void (*old_##SIG##_handler) (int);
   SIGNALS
@@ -2179,6 +2187,8 @@ public:
     bool first = true;
     bool deallocated = false;
     for (size_t i = 0; i < calls.size (); i++) {
+      if (Signal::interrupted ())
+        break;
       Call *c = calls[i];
 
 #ifdef MOBICAL_MEMORY
@@ -3548,6 +3558,10 @@ int Trace::fork_and_execute () {
 
     executed++;
 
+    // If SIGTSTP is used in the future rather use waitpid & WUNTRACED
+    // int status;
+    // pid_t other = waitpid (child, &status, WUNTRACED); 
+
     int status, other = wait (&status);
     if (other != child)
       res = 0;
@@ -3657,7 +3671,11 @@ bool Trace::shrink_segments (Trace::Segments &segments, int expected) {
       } else {
         res = true; // succeeded to shrink
       }
+      if (Signal::interrupted ())
+        break;
     }
+    if (Signal::interrupted ())
+      break;
     if (granularity == 1)
       break;
     granularity = (granularity + 1) / 2;
@@ -3779,6 +3797,8 @@ void Mobical::notify (Trace &trace, signed char ch) {
 bool Trace::shrink_phases (int expected) {
   if (mobical.donot.shrink.phases)
     return false;
+  if (Signal::interrupted ())
+    return false;
   notify ('p');
   size_t l;
   for (l = 1; l < size () && config_type (calls[l]->type); l++)
@@ -3813,6 +3833,8 @@ bool Trace::shrink_phases (int expected) {
 bool Trace::shrink_clauses (int expected) {
   if (mobical.donot.shrink.clauses)
     return false;
+  if (Signal::interrupted ())
+    return false;
   notify ('c');
   Segments segments;
   for (size_t r = size (), l; r > 1; r = l) {
@@ -3831,6 +3853,8 @@ bool Trace::shrink_clauses (int expected) {
 
 bool Trace::shrink_lemmas (int expected) {
   if (mobical.donot.shrink.lemmas)
+    return false;
+  if (Signal::interrupted ())
     return false;
   notify ('u');
   Segments segments;
@@ -3852,6 +3876,8 @@ bool Trace::shrink_lemmas (int expected) {
 //
 bool Trace::shrink_literals (int expected) {
   if (mobical.donot.shrink.literals)
+    return false;
+  if (Signal::interrupted ())
     return false;
   notify ('l');
   Segments segments;
@@ -3899,6 +3925,8 @@ static bool is_basic (Call *c) {
 
 bool Trace::shrink_basic (int expected) {
   if (mobical.donot.shrink.basic)
+    return false;
+  if (Signal::interrupted ())
     return false;
   notify ('b');
   Segments segments;
@@ -3964,6 +3992,8 @@ bool Trace::shrink_disable (int expected) {
 
   if (mobical.donot.disable)
     return false;
+  if (Signal::interrupted ())
+    return false;
   const int max_var = vars ();
 
   notify ('d');
@@ -4017,7 +4047,11 @@ bool Trace::shrink_disable (int expected) {
           c->val = saved[j];
         }
       }
+      if (Signal::interrupted ())
+        break;
     }
+    if (Signal::interrupted ())
+      break;
     if (granularity == 1)
       break;
     granularity = (granularity + 1) / 2;
@@ -4032,6 +4066,8 @@ bool Trace::reduce_values (int expected) {
 
   if (mobical.donot.reduce)
     return false;
+  if (Signal::interrupted ())
+    return false;
 
   notify ('r');
 
@@ -4039,6 +4075,10 @@ bool Trace::reduce_values (int expected) {
 
   bool changed = false, res = false;
   do {
+    if (Signal::interrupted ()) {
+      res = false;
+      break;
+    }
     if (changed)
       res = true;
     changed = false;
@@ -4082,12 +4122,19 @@ bool Trace::reduce_values (int expected) {
       int old_val = c->val;
       c->val = lo;
       progress ();
-      if (fork_and_execute () == expected) {
+
+      bool success = fork_and_execute () == expected;
+      if (success) {
         assert (c->val != old_val);
         changed = true;
+      } else
+        c->val = old_val;
+
+      if (Signal::interrupted ())
+        break;
+
+      if (success)
         continue;
-      }
-      c->val = old_val;
 
       // Then try to limit to the high value if current value too large.
       //
@@ -4095,13 +4142,17 @@ bool Trace::reduce_values (int expected) {
         int old_val = c->val;
         c->val = hi;
         progress ();
-        if (fork_and_execute () == expected) {
+        success = fork_and_execute () == expected;
+        if (success) {
           assert (c->val != old_val);
           changed = true;
-        } else {
+        } else
           c->val = old_val;
+
+        if (Signal::interrupted ())
+          break;
+        if (!success)
           continue;
-        }
       }
 
       // Now we do a delta-debugging inspired binary search for the smallest
@@ -4124,6 +4175,8 @@ bool Trace::reduce_values (int expected) {
           changed = true;
         } else
           c->val = old_val;
+        if (Signal::interrupted ())
+          break;
       }
     }
   } while (changed);
@@ -4158,6 +4211,8 @@ static bool has_lit_arg_type (Call *c) {
 
 void Trace::map_variables (int expected) {
   if (mobical.donot.map)
+    return;
+  if (Signal::interrupted ())
     return;
   for (int with_gaps = 0; with_gaps <= 1; with_gaps++) {
     notify ('m');
@@ -4216,6 +4271,8 @@ void Trace::map_variables (int expected) {
       with_gaps = 2;
     }
     notify ();
+    if (Signal::interrupted ())
+      break;
   }
 }
 
@@ -4225,7 +4282,8 @@ void Trace::shrink_options (int expected) {
 
   if (mobical.donot.shrink.options)
     return;
-
+  if (Signal::interrupted ())
+    return;
   notify ('o');
   Segments segments;
   for (size_t i = 0; i < size (); i++) {
@@ -4281,7 +4339,8 @@ void Trace::shrink (int expected) {
   shrink_options (expected);
   // Execute one last time to get accurate results when memory fuzzing
   // is enabled.
-  fork_and_execute ();
+  if (!Signal::interrupted ())
+    fork_and_execute ();
   cerr << flush;
   mobical.shrinking = false;
 }
@@ -4960,13 +5019,11 @@ Mobical::~Mobical () {
     delete mock_pointer;
 }
 
-void Mobical::catch_signal (int) {
-  if ((terminal && (mode & RANDOM)) || shrinking || running)
-    cerr << endl;
-  terminal.reset ();
+void Mobical::catch_signal (int sig) {
+  Signal::set_received (sig);
+
   if (Trace::executed && !Trace::failed && !Trace::ok)
     assert (mode & (INPUT | SEED)), Trace::failed = 1;
-  print_statistics ();
 }
 
 /*------------------------------------------------------------------------*/
@@ -5472,6 +5529,9 @@ END_OF_BANNER_AND_OPTIONS:
 
     for (traces = 1; traces <= limit; traces++) {
 
+      if (Signal::interrupted ())
+        break;
+
       if (!quiet && !donot.seeds) {
         prefix ();
         cerr << ' ' << left << setw (15) << traces << ' ';
@@ -5565,11 +5625,16 @@ END_OF_BANNER_AND_OPTIONS:
     }
   }
 
+  const int sig = Signal::received ();
+  const bool reraise = Signal::interrupted ();
   Signal::reset ();
 
   terminal.reset ();
   print_statistics ();
 
+  if (reraise)
+    raise (sig);
+  
   return Trace::failed > 0;
 }
 

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -392,7 +392,7 @@ const char *Parser::parse_solution_non_profiled () {
   clear_n (external->solution, external->max_var + 1u);
   int ch;
   for (;;) {
-    if (internal->terminated_asynchronously ()) // SIGTODO: review
+    if (internal->terminated_asynchronously ())
       return "parsing solution interrupted by signal";
     ch = parse_char ();
     if (ch == EOF)

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -269,7 +269,8 @@ const char *Parser::parse_dimacs_non_profiled (int &vars, int strict) {
         break;
       continue;
     }
-    internal->terminated_asynchronously ();
+    if (internal->terminated_asynchronously ()) 
+      return "parsing interrupted by signal";
     if (ch == 'a' && found_inccnf_header)
       break;
     const char *err = parse_lit (ch, lit, vars, strict);
@@ -329,7 +330,8 @@ const char *Parser::parse_dimacs_non_profiled (int &vars, int strict) {
           break;
         continue;
       }
-      internal->terminated_asynchronously ();
+      if (internal->terminated_asynchronously ())
+        return "parsing interrupted by signal";
       const char *err = parse_lit (ch, lit, vars, strict);
       if (err == cube_token)
         PER ("two 'a' in a row");
@@ -390,6 +392,8 @@ const char *Parser::parse_solution_non_profiled () {
   clear_n (external->solution, external->max_var + 1u);
   int ch;
   for (;;) {
+    if (internal->terminated_asynchronously ()) // SIGTODO: review
+      return "parsing solution interrupted by signal";
     ch = parse_char ();
     if (ch == EOF)
       PER ("missing 's' line");

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -269,6 +269,7 @@ const char *Parser::parse_dimacs_non_profiled (int &vars, int strict) {
         break;
       continue;
     }
+    internal->terminated_asynchronously ();
     if (ch == 'a' && found_inccnf_header)
       break;
     const char *err = parse_lit (ch, lit, vars, strict);
@@ -328,6 +329,7 @@ const char *Parser::parse_dimacs_non_profiled (int &vars, int strict) {
           break;
         continue;
       }
+      internal->terminated_asynchronously ();
       const char *err = parse_lit (ch, lit, vars, strict);
       if (err == cube_token)
         PER ("two 'a' in a row");

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -915,6 +915,8 @@ void CaDiCaL::Internal::inprobe (bool update_limits) {
 
   if (unsat)
     return;
+  if (terminated_asynchronously ())
+    return;
   if (level)
     backtrack ();
   if (!propagate ()) {

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -86,12 +86,6 @@ const char *Signal::name (int sig) {
   return "UNKNOWN";
 }
 
-// TODO printing is not reentrant and might lead to deadlock if the signal
-// is raised during another print attempt (and locked IO is used).  To avoid
-// this we have to either run our own low-level printing routine here or in
-// 'Message' or just dump those statistics somewhere else were we have
-// exclusive access to.  All these solutions are painful and not elegant.
-
 static void catch_signal (int sig) {
 #ifndef _WIN32
   if (sig == SIGALRM && absolute_real_time () >= alarm_time) {
@@ -105,8 +99,9 @@ static void catch_signal (int sig) {
 #endif
   {
     // Reraising should happen in solver control for SIGINT and SIGTERM.
+    // For SIGABRT and SIGSEGV we reraise immediately.
     switch (sig) {
-    case SIGABRT: // Better not return control for these two
+    case SIGABRT: 
     case SIGSEGV:
       Signal::reset ();
       ::raise (sig);

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -19,6 +19,7 @@ extern "C" {
 
 namespace CaDiCaL {
 
+static volatile sig_atomic_t signal_value = 0;
 static volatile bool caught_signal = false;
 static Handler *signal_handler;
 
@@ -69,6 +70,7 @@ void Signal::reset () {
   reset_alarm ();
 #endif
   caught_signal = false;
+  signal_value = 0;
 }
 
 const char *Signal::name (int sig) {
@@ -102,13 +104,20 @@ static void catch_signal (int sig) {
   } else
 #endif
   {
+    // Reraising should happen in solver control for SIGINT and SIGTERM.
+    switch (sig) {
+    case SIGABRT: // Better not return control for these two
+    case SIGSEGV:
+      Signal::reset ();
+      ::raise (sig);
+    default:
+      break;
+    }
     if (!caught_signal) {
       caught_signal = true;
       if (signal_handler)
         signal_handler->catch_signal (sig);
     }
-    Signal::reset ();
-    ::raise (sig);
   }
 }
 
@@ -132,5 +141,19 @@ void Signal::alarm (int seconds) {
 }
 
 #endif
+
+void Signal::set_received (int sig) {
+  signal_value = sig;
+}
+
+int Signal::received () {
+  return signal_value;
+}
+
+// Signals for which returning control is sensible
+bool Signal::interrupted () {
+  const int sig = received ();
+  return sig == SIGINT || sig == SIGTERM;
+}
 
 } // namespace CaDiCaL

--- a/src/signal.hpp
+++ b/src/signal.hpp
@@ -26,6 +26,10 @@ public:
 #endif
 
   static const char *name (int sig);
+
+  static void set_received (int sig);
+  static int received ();
+  static bool interrupted ();
 };
 
 } // namespace CaDiCaL

--- a/src/subsume.cpp
+++ b/src/subsume.cpp
@@ -380,7 +380,8 @@ bool Internal::subsume_round () {
   int64_t left_over_from_last_subsumption_round = 0;
 
   for (auto c : clauses) {
-
+    if (terminated_asynchronously ())
+      break;
     if (c->garbage)
       continue;
     if (c->size > opts.subsumeclslim)

--- a/src/sweep.cpp
+++ b/src/sweep.cpp
@@ -102,6 +102,8 @@ void Internal::sweep_dense_mode_and_watch_irredundant () {
   // Connect irredundant clauses.
   //
   for (const auto &c : clauses) {
+    if (terminated_asynchronously ())
+      break;
     if (!c->garbage) {
       for (const auto &lit : *c)
         if (active (lit))
@@ -394,7 +396,7 @@ static void save_core_clause (void *state, unsigned id, bool learned,
                               size_t size, const unsigned *lits) {
   Sweeper *sweeper = (Sweeper *) state;
   Internal *internal = sweeper->internal;
-  if (internal->unsat)
+  if (internal->unsat || internal->terminated_asynchronously ())
     return;
   vector<sweep_proof_clause> &core = sweeper->core[sweeper->save];
   sweep_proof_clause pc;
@@ -426,7 +428,7 @@ static void save_core_clause_with_lrat (void *state, unsigned cid,
                                         const unsigned *chain) {
   Sweeper *sweeper = (Sweeper *) state;
   Internal *internal = sweeper->internal;
-  if (internal->unsat)
+  if (internal->unsat || internal->terminated_asynchronously ())
     return;
   vector<sweep_proof_clause> &core = sweeper->core[sweeper->save];
   vector<Clause *> &clauses = sweeper->clauses;
@@ -621,8 +623,13 @@ void Internal::clear_core (Sweeper &sweeper, unsigned core_idx) {
 
 void Internal::save_add_clear_core (Sweeper &sweeper) {
   save_core (sweeper, 0);
-  add_core (sweeper, 0);
-  clear_core (sweeper, 0);
+  // now skip adding the core completely if terminated_asynchronously.
+  // Else need full adding and clearing (including proof deletion steps)
+  if (!terminated_asynchronously ()) {
+    add_core (sweeper, 0);
+    clear_core (sweeper, 0);  
+  } else
+    sweeper.core[0].clear (); // just clear the (possibly partially) filled vec
 }
 
 void Internal::init_backbone_and_partition (Sweeper &sweeper) {
@@ -650,7 +657,7 @@ void Internal::init_backbone_and_partition (Sweeper &sweeper) {
 void Internal::sweep_empty_clause (Sweeper &sweeper) {
   assert (!unsat);
   save_add_clear_core (sweeper);
-  assert (unsat);
+  assert (unsat || terminated_asynchronously ());
 }
 
 void Internal::sweep_refine_partition (Sweeper &sweeper) {
@@ -876,7 +883,7 @@ bool Internal::sweep_backbone_candidate (Sweeper &sweeper, int lit) {
   if (res == 20) {
     LOG ("sweep unit %d", lit);
     save_add_clear_core (sweeper);
-    assert (val (lit));
+    assert (val (lit) || terminated_asynchronously ());
     stats.sweep_unsat_backbone++;
     return true;
   }
@@ -1459,7 +1466,11 @@ bool Internal::sweep_equivalence_candidates (Sweeper &sweeper, int lit,
   LOG ("second sweeping implication %d <- %d succeeded too", other, lit);
 
   save_core (sweeper, 1);
-
+  if (terminated_asynchronously ()) {
+    sweeper.core[0].clear ();
+    sweeper.core[1].clear ();
+    return false;
+  }
   LOG ("sweep equivalence %d = %d", lit, other);
 
   // If kitten behaves as expected, the two binaries of the equivalence
@@ -1746,6 +1757,8 @@ bool Internal::scheduable_variable (Sweeper &sweeper, int idx,
 }
 
 unsigned Internal::schedule_all_other_not_scheduled_yet (Sweeper &sweeper) {
+  if (terminated_asynchronously ())
+    return 0;
   vector<sweep_candidate> fresh;
   for (const auto &idx : vars) {
     Flags &f = flags (idx);
@@ -1775,6 +1788,8 @@ unsigned Internal::schedule_all_other_not_scheduled_yet (Sweeper &sweeper) {
 
 unsigned Internal::reschedule_previously_remaining (Sweeper &sweeper) {
   unsigned rescheduled = 0;
+  if (terminated_asynchronously ())
+    return rescheduled;
   for (const auto &idx : sweep_schedule) {
     Flags &f = flags (idx);
     if (!f.active ())
@@ -1850,7 +1865,7 @@ void Internal::unschedule_sweeping (Sweeper &sweeper, unsigned swept,
 #ifdef QUIET
   (void) scheduled, (void) swept;
 #endif
-  assert (sweep_schedule.empty ());
+  assert (sweep_schedule.empty () || terminated_asynchronously ());
   assert (sweep_incomplete);
   for (all_scheduled (idx))
     if (active (idx)) {

--- a/src/ternary.cpp
+++ b/src/ternary.cpp
@@ -282,6 +282,8 @@ bool Internal::ternary_round (int64_t &steps_limit, int64_t &htrs_limit) {
       continue;
     if (c->size > 3)
       continue;
+    if (terminated_asynchronously ())
+      break;
     bool assigned = false, marked = false;
     for (const auto &lit : *c) {
       if (val (lit)) {

--- a/src/watch.cpp
+++ b/src/watch.cpp
@@ -26,7 +26,7 @@ void Internal::reset_watches () {
 void Internal::connect_watches (bool irredundant_only) {
   START (connect);
   assert (watching ());
-
+  report (':'); // SIGTODO: remove after debugging
   LOG ("watching all %sclauses", irredundant_only ? "irredundant " : "");
 
   // First connect binary clauses.
@@ -72,7 +72,7 @@ void Internal::connect_watches (bool irredundant_only) {
       }
     }
   }
-
+  report (':'); // SIGTODO: remove after debugging
   STOP (connect);
 }
 

--- a/src/watch.cpp
+++ b/src/watch.cpp
@@ -26,7 +26,6 @@ void Internal::reset_watches () {
 void Internal::connect_watches (bool irredundant_only) {
   START (connect);
   assert (watching ());
-  report (':'); // SIGTODO: remove after debugging
   LOG ("watching all %sclauses", irredundant_only ? "irredundant " : "");
 
   // First connect binary clauses.
@@ -72,7 +71,6 @@ void Internal::connect_watches (bool irredundant_only) {
       }
     }
   }
-  report (':'); // SIGTODO: remove after debugging
   STOP (connect);
 }
 


### PR DESCRIPTION
Ported the new signal handling implementation, originally developed on `development`, to `rel-3.0.1`. Also includes a proposed macOS-specific fix for Mobical allocator initialization.