### PR TITLE
Fix for memory usage statistics on Apple

### DIFF
--- a/src/mobical.cpp
+++ b/src/mobical.cpp
@@ -3356,7 +3356,11 @@ void Trace::child_signal_handler (int sig) {
 
   struct rusage u;
   if (!getrusage (RUSAGE_SELF, &u)) {
+#ifdef __APPLE__
+    if ((int64_t) u.ru_maxrss >> 20 >= mobical.space_limit) {
+#else
     if ((int64_t) u.ru_maxrss >> 10 >= mobical.space_limit) {
+#endif
       if (mobical.shared)
         mobical.shared->memout++;
       // Since there is no memout signal we just misuse SIXCPU to notify the

--- a/src/mobical.cpp
+++ b/src/mobical.cpp
@@ -3356,10 +3356,10 @@ void Trace::child_signal_handler (int sig) {
 
   struct rusage u;
   if (!getrusage (RUSAGE_SELF, &u)) {
-#ifdef __APPLE__
-    if ((int64_t) u.ru_maxrss >> 20 >= mobical.space_limit) {
-#else
+#ifndef __APPLE__
     if ((int64_t) u.ru_maxrss >> 10 >= mobical.space_limit) {
+#else
+    if ((int64_t) u.ru_maxrss >> 20 >= mobical.space_limit) {
 #endif
       if (mobical.shared)
         mobical.shared->memout++;

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -130,7 +130,11 @@ uint64_t maximum_resident_set_size () {
   struct rusage u;
   if (getrusage (RUSAGE_SELF, &u))
     return 0;
+#ifndef __APPLE__
   return ((uint64_t) u.ru_maxrss) << 10;
+#else
+  return ((uint64_t) u.ru_maxrss);
+#endif
 }
 
 // Unfortunately 'getrusage' on Linux does not support current resident set


### PR DESCRIPTION
On Apple ru_maxrss is in bytes while on Linux it is in KiB.