### PR TITLE
Balance profiling on interrupted congruence merging

### DIFF
--- a/src/congruence.cpp
+++ b/src/congruence.cpp
@@ -4883,8 +4883,10 @@ size_t Closure::propagate_units_and_equivalences () {
   LOG ("propagating at least %zd units", schedule.size ());
   assert (lrat_chain.empty ());
   while (propagate_units () && !schedule.empty ()) {
-    if (internal->terminated_asynchronously ())
+    if (internal->terminated_asynchronously ()) {
+      STOP (congruencemerge);
       return 0;
+    }
     assert (!internal->unsat);
     assert (lrat_chain.empty ());
     ++propagated;


### PR DESCRIPTION
`Closure::propagate_units_and_equivalences` starts the `congruencemerge` profile but returns early on asynchronous termination without stopping it. Since `Internal::start_profiling` asserts `!profile.active`, a later run of the congruence pass in the same (e.g. incremental) solving session fails that assertion in debug builds; in release builds the profile timing is silently corrupted. All other early exits in `congruence.cpp` stop their profile before returning; this makes the remaining one consistent.

Found while working on a ticks budget for the congruence pass (#179); submitted separately since it is an independent fix.

Single signed-off commit as per CONTRIBUTING.md; `make test` passes in release and debug builds.
