### PR TITLE
Fix lrat-trim rejecting valid proofs

### DIFF
--- a/test/cnf/lrat-trim.c
+++ b/test/cnf/lrat-trim.c
@@ -883,6 +883,15 @@ static void mark_used_literals (int *literals) {
   }
 }
 
+static void unmark_used_literals (int *literals) {
+  for (int *l = literals, lit; (lit = *l); l++) {
+    size_t *count = &COUNT (lit);
+    assert (*count);
+    if (*count != SIZE_MAX)
+      (*count)--;
+  }
+}
+
 static void check_strict_clause_extension (int id, int *literals,
                                            int *antecedents) {
   assert (strict);
@@ -1588,6 +1597,8 @@ static void delete_antecedent (int other, bool binary, size_t info) {
     if (!relax || other < SIZE (clauses.literals)) {
 
       int **l = &ACCESS (clauses.literals, other);
+      if (status > 0 && !norat && (checking || is_original_clause (other)))
+        unmark_used_literals (*l);
       free (*l);
       *l = 0;
     }


### PR DESCRIPTION
I've been working on a system to generate LRAT proofs for the equivalence of large multipliers (eg. array vs Booth, Wallace vs Dadda, etc), and I've been using lrat-trim as a convenient checker. It's fast and it supports binary LRAT, which is good as the proofs can be quite large for big multipliers (given the multipliers's CNF grows quadratically with bit width, and the proofs grow similarly).

I've had to use the development branch, as the lrat-trim on master assumes that the RAT pivot is a new variable. I often need several clauses to introduce an extension variable, so it then rejects the subsequent RAT clauses. The development version works better, as it assumes the first variable is the pivot.

Unfortunately I've found a case where it rejects valid proofs in forward mode. The defect exists on master also, although additionally main will actually segfault with '-S -s' instead of just '-S' (that's fixed in development though).

Here's an example of a proof that is rejected:

DIMACS:

```
p cnf 4 5
-4 2 0
-4 3 0
1 0
-1 0
-2 0
```

LRAT:

```
5 d 2 0
6 4 -2 0 -1 0
7 0 3 4 0
```

cake_lpr accepts the proofs just fine. It also works fine with lrat-trim in the default backwards mode. The bug seems quite simple, it's just failing to decrement the occurrence count when a deletion releases a clause eagerly.