### PR TITLE
Move class Reap into CaDiCaL namespace

### DIFF
--- a/src/reap.cpp
+++ b/src/reap.cpp
@@ -3,6 +3,8 @@
 #include <climits>
 #include <cstring>
 
+namespace CaDiCaL {
+
 void Reap::init () {
   for (auto &bucket : buckets)
     bucket = {0};
@@ -125,3 +127,5 @@ void Reap::clear () {
   min_bucket = 32;
   max_bucket = 0;
 }
+
+} // namespace CaDiCaL

--- a/src/reap.hpp
+++ b/src/reap.hpp
@@ -4,6 +4,8 @@
 #include <cstddef>
 #include <vector>
 
+namespace CaDiCaL {
+
 class Reap {
 public:
   Reap ();
@@ -24,5 +26,7 @@ private:
   unsigned max_bucket;
   std::vector<unsigned> buckets[33];
 };
+
+} // namespace CaDiCaL
 
 #endif


### PR DESCRIPTION
`Reap` is the only type the library declares at global scope; everything else lives in `namespace CaDiCaL`. 